### PR TITLE
fix: better workflow triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,13 @@ on:
     workflows: ["Rust"]
     types:
       - completed
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+$"
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      startsWith(github.event.workflow_run.head_branch, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Setup ssh-agent

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,8 @@ name: Rust
 on:
   push:
     branches: [main]
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+$"
   pull_request:
 
 jobs:


### PR DESCRIPTION
rust.yml is now triggered by versioning tags as well 
release.yml is triggered only if rust.yml succeeds and head/branch starts with refs/tag