### PR TITLE
fix: copy forge to the correct target directory even if --target is set

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,6 +102,8 @@ jobs:
 
   # TODO: eventually move this to a separate workflow
   release:
+    needs: [unit-test, fmt, lint, build]
+    if: startsWith(github.ref, 'refs/tags/')
     timeout-minutes: 60 # 60 minutes
     name: Create Release for ${{ matrix.target }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -119,8 +121,6 @@ jobs:
             os: ubuntu-latest
     permissions:
       contents: write
-    needs: [unit-test, fmt, lint, build]
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Setup ssh-agent

--- a/bin/pcl/build.rs
+++ b/bin/pcl/build.rs
@@ -18,6 +18,7 @@ pub fn main() -> Result<()> {
     // Environment flags
     println!("cargo:rerun-if-env-changed=PCL_SKIP_UPDATE_PHOUNDRY");
     println!("cargo:rerun-if-env-changed=PCL_SKIP_BUILD_PHOUNDRY");
+    println!("cargo:rerun-if-env-changed=TARGET");
 
     let skip_build_phoundry = env::var("PCL_SKIP_BUILD_PHOUNDRY")
         .map(|val| val.to_lowercase() == "true")
@@ -57,7 +58,14 @@ pub fn main() -> Result<()> {
         .join(&profile)
         .join("forge");
 
-    let dest = workspace_root.join("target").join(&profile).join("phorge");
+    // Determine the correct target directory
+    let target_dir = if let Ok(target) = env::var("TARGET") {
+        workspace_root.join("target").join(target).join(&profile)
+    } else {
+        workspace_root.join("target").join(&profile)
+    };
+
+    let dest = target_dir.join("phorge");
 
     println!(
         "cargo:warning=Copying {} to {}",

--- a/bin/pcl/build.rs
+++ b/bin/pcl/build.rs
@@ -88,14 +88,21 @@ fn update_phoundry(workspace_root: &Path) -> std::io::Result<()> {
 }
 
 fn build_phoundry(workspace_root: &Path, mode: &str) -> std::io::Result<()> {
-    let mut args = vec!["build", "--bin", "forge"];
+    let mut command = Command::new("cargo");
+    command
+        .current_dir(workspace_root.join("phoundry"))
+        .arg("build")
+        .arg("--bin")
+        .arg("forge");
+
     if mode == "release" {
-        args.push("--release");
+        command.arg("--release");
     }
 
-    Command::new("cargo")
-        .current_dir(workspace_root.join("phoundry"))
-        .args(&args)
-        .status()?;
+    if let Ok(target_value) = env::var("TARGET") {
+        command.arg("--target").arg(target_value);
+    }
+
+    command.status()?;
     Ok(())
 }

--- a/bin/pcl/build.rs
+++ b/bin/pcl/build.rs
@@ -19,6 +19,7 @@ pub fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed=PCL_SKIP_UPDATE_PHOUNDRY");
     println!("cargo:rerun-if-env-changed=PCL_SKIP_BUILD_PHOUNDRY");
     println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo:rerun-if-env-changed=OUT_DIR");
 
     let skip_build_phoundry = env::var("PCL_SKIP_BUILD_PHOUNDRY")
         .map(|val| val.to_lowercase() == "true")
@@ -51,21 +52,19 @@ pub fn main() -> Result<()> {
     // Build phoundry/forge
     build_phoundry(workspace_root, &profile).expect("Failed to build phoundry");
 
-    // Copy the forge binary to the main target directory instead of OUT_DIR
+    let target = env::var("TARGET").ok().unwrap();
+
     let source = workspace_root
         .join("phoundry")
         .join("target")
+        .join(&target)
         .join(&profile)
         .join("forge");
 
-    // Determine the correct target directory
-    let target_dir = if let Ok(target) = env::var("TARGET") {
-        workspace_root.join("target").join(target).join(&profile)
-    } else {
-        workspace_root.join("target").join(&profile)
-    };
+    let target_dir = get_profile_dir(&std::env::var("OUT_DIR").unwrap());
+    println!("cargo:warning=Target directory: {}", target_dir);
 
-    let dest = target_dir.join("phorge");
+    let dest = Path::new(&target_dir).join("phorge");
 
     println!(
         "cargo:warning=Copying {} to {}",
@@ -76,6 +75,7 @@ pub fn main() -> Result<()> {
 
     println!("cargo:rerun-if-changed={}", source.display());
     println!("cargo:rerun-if-changed=phoundry");
+
     Ok(())
 }
 
@@ -102,7 +102,48 @@ fn build_phoundry(workspace_root: &Path, mode: &str) -> std::io::Result<()> {
     if let Ok(target_value) = env::var("TARGET") {
         command.arg("--target").arg(target_value);
     }
-
     command.status()?;
     Ok(())
+}
+
+fn get_profile_dir(out_dir: &str) -> String {
+    let profile = std::env::var("PROFILE").unwrap(); // "debug" or "release"
+
+    // Normalize path separators to forward slashes
+    let normalized_path = out_dir.replace('\\', "/");
+
+    // Split the path into components, filtering out empty strings
+    let components: Vec<&str> = normalized_path
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Find the index of the profile directory
+    if let Some(profile_idx) = components.iter().position(|&c| c == profile) {
+        // Reconstruct the path up to and including the profile directory
+        let path_components = &components[..=profile_idx];
+
+        // Check if original path was absolute (started with slash)
+        let is_absolute = out_dir.starts_with('/')
+            || (out_dir.len() >= 2 && &out_dir[..2] == "\\\\")
+            || (out_dir.chars().nth(1) == Some(':')); // Windows drive letter
+
+        if is_absolute {
+            if out_dir.chars().nth(1) == Some(':') {
+                // Windows path
+                // Reconstruct Windows path with drive letter
+                format!("{}:\\{}", components[0], path_components[1..].join("\\"))
+            } else {
+                // Unix absolute path
+                format!("/{}", path_components.join("/"))
+            }
+        } else {
+            // Relative path
+            path_components.join("/")
+        }
+    } else {
+        // Fallback if profile not found in path
+        eprintln!("Warning: Could not find profile directory in OUT_DIR");
+        out_dir.to_string()
+    }
 }


### PR DESCRIPTION
Note: 

- I had to adjust the build script to support specific target builds for phorge as well. 
- additionally I had to make it work that forge is going to be copied into the correct pcl bin target directory

if cargo build is called without `--target` it's gonna be stored in `target/<profile>`
if built with --target set it's gonna be stored int `target/<target_triple>/<profile>`

Unfortunately, the only way to figure out if --target is set or not, was by analyzing the `OUT_DIR` variable. 
It's a bit hacky but good enough for now IMO. 

In the future we might want to switch to https://github.com/cross-rs/cross