### PR TITLE
add simple lending example, fix ownable tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = phoundry
 	url = https://github.com/phylaxsystems/phoundry
 	branch = pcl
+[submodule "testdata/mock-protocol/lib/openzeppelin-contracts"]
+	path = testdata/mock-protocol/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/testdata/mock-protocol/assertions/src/PriceFeedAssertion.a.sol
+++ b/testdata/mock-protocol/assertions/src/PriceFeedAssertion.a.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../lib/credible-std/src/Assertion.sol";
+import {IPriceFeed} from "../../src/SimpleLending.sol";
+
+contract PriceFeedAssertion is Assertion {
+    IPriceFeed tokenPriceFeed;
+
+    constructor(address tokenPriceFeed_) {
+        tokenPriceFeed = IPriceFeed(tokenPriceFeed_);
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.assertionPriceDeviation.selector);
+    }
+
+    function assertionPriceDeviation() external {
+        uint256[] memory stateChanges = getStateChangesUint(address(tokenPriceFeed), 0x0);
+        ph.forkPreState();
+        // Get price before the transaction
+        uint256 preTokenPrice = tokenPriceFeed.getPrice();
+        ph.forkPostState();
+
+        // Maximum allowed price deviation is 10% up or down
+        uint256 maxPrice = (preTokenPrice * 110) / 100; // +10%
+        uint256 minPrice = (preTokenPrice * 90) / 100; // -10%
+
+        for (uint256 i = 0; i < stateChanges.length; i++) {
+            uint256 price = stateChanges[i];
+            if (price > maxPrice || price < minPrice) {
+                revert("Price deviation exceeds 10% threshold");
+            }
+        }
+    }
+}

--- a/testdata/mock-protocol/assertions/src/SimpleLendingAssertion.a.sol
+++ b/testdata/mock-protocol/assertions/src/SimpleLendingAssertion.a.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Assertion} from "../../lib/credible-std/src/Assertion.sol";
+import {SimpleLending} from "../../src/SimpleLending.sol";
+import {IPriceFeed} from "../../src/SimpleLending.sol";
+import {console} from "../../lib/credible-std/lib/forge-std/src/console.sol";
+import {PhEvm} from "../../lib/credible-std/src/PhEvm.sol";
+
+contract SimpleLendingAssertion is Assertion {
+    SimpleLending simpleLending;
+
+    constructor(address simpleLending_) {
+        simpleLending = SimpleLending(simpleLending_);
+    }
+
+    function triggers() external view override {
+        registerCallTrigger(this.assertionIndividualPosition.selector);
+        registerCallTrigger(this.assertionBorrowedInvariant.selector);
+        registerCallTrigger(this.assertionEthDrain.selector);
+    }
+
+    // Verify that total borrowed tokens never exceed total collateral value
+    function assertionBorrowedInvariant() external {
+        ph.forkPostState();
+
+        // Get price feeds directly from the lending contract
+        IPriceFeed ethPriceFeed = simpleLending.ethPriceFeed();
+        IPriceFeed tokenPriceFeed = simpleLending.tokenPriceFeed();
+
+        uint256 ethPrice = ethPriceFeed.getPrice();
+        uint256 tokenPrice = tokenPriceFeed.getPrice();
+
+        // Rearrange calculation to avoid potential overflow
+        uint256 collateralValue = (simpleLending.totalCollateral() * ethPrice) / 1e18;
+        uint256 borrowedValue = (simpleLending.totalBorrowed() * tokenPrice) / 1e18;
+
+        // Must maintain 75% collateral ratio
+        require(
+            collateralValue * simpleLending.COLLATERAL_RATIO() >= borrowedValue * 100,
+            "Borrowed tokens exceed collateral value"
+        );
+    }
+
+    // Prevent large sudden drops in total collateral
+    function assertionEthDrain() external {
+        uint256 MAX_WITHDRAWAL_PERCENT = 50; // 50%
+        ph.forkPreState();
+
+        uint256 preTotalCollateral = simpleLending.totalCollateral();
+
+        ph.forkPostState();
+        uint256 postTotalCollateral = simpleLending.totalCollateral();
+
+        if (postTotalCollateral >= preTotalCollateral) {
+            return;
+        }
+
+        uint256 withdrawalPercent = ((preTotalCollateral - postTotalCollateral) * 100) / preTotalCollateral;
+        require(withdrawalPercent <= MAX_WITHDRAWAL_PERCENT, "Withdrawal percentage too high");
+    }
+
+    // Verify individual position maintains required collateral ratio
+    function assertionIndividualPosition() external {
+        ph.forkPostState();
+
+        // Get the caller from call inputs
+        PhEvm.CallInputs[] memory calls = ph.getCallInputs(address(simpleLending), simpleLending.withdraw.selector);
+        if (calls.length == 0) {
+            return;
+        }
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            address caller = calls[i].caller;
+
+            // Get price feeds
+            IPriceFeed ethPriceFeed = simpleLending.ethPriceFeed();
+            IPriceFeed tokenPriceFeed = simpleLending.tokenPriceFeed();
+
+            uint256 ethPrice = ethPriceFeed.getPrice();
+            uint256 tokenPrice = tokenPriceFeed.getPrice();
+
+            // Check the specific position that was modified
+            (uint256 collateral, uint256 borrowed) = simpleLending.positions(caller);
+            if (borrowed > 0) {
+                // Only check positions with outstanding borrows
+                uint256 collateralValue = (collateral * ethPrice) / 1e18;
+                uint256 borrowedValue = (borrowed * tokenPrice) / 1e18;
+
+                require(
+                    collateralValue * simpleLending.COLLATERAL_RATIO() >= borrowedValue * 100,
+                    "Individual position undercollateralized"
+                );
+            }
+        }
+    }
+}

--- a/testdata/mock-protocol/assertions/test/PriceFeedAssertion.t.sol
+++ b/testdata/mock-protocol/assertions/test/PriceFeedAssertion.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {PriceFeedAssertion} from "../src/PriceFeedAssertion.a.sol";
+import {IPriceFeed} from "../../src/SimpleLending.sol";
+import {MockTokenPriceFeed} from "../../src/SimpleLending.sol";
+import {Test} from "../../lib/credible-std/lib/forge-std/src/Test.sol";
+import {CredibleTest} from "../../lib/credible-std/src/CredibleTest.sol";
+
+contract TestPriceFeedAssertion is CredibleTest, Test {
+    BatchTokenPriceUpdates public batchTokenPriceUpdates;
+    MockTokenPriceFeed public assertionAdopter;
+
+    function setUp() public {
+        assertionAdopter = new MockTokenPriceFeed();
+        vm.deal(address(0xdeadbeef), 1 ether);
+    }
+
+    function testBatchPriceUpdates() public {
+        BatchTokenPriceUpdates updater = new BatchTokenPriceUpdates(address(assertionAdopter));
+
+        vm.prank(address(0xdeadbeef));
+        // Set initial token price
+        assertionAdopter.setPrice(1 ether);
+
+        cl.addAssertion(
+            "PriceFeedAssertion",
+            address(assertionAdopter),
+            type(PriceFeedAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        vm.prank(address(0xdeadbeef));
+        vm.expectRevert("Assertions Reverted");
+        // Execute batch price updates in validate
+        cl.validate("PriceFeedAssertion", address(updater), 0, new bytes(0));
+    }
+
+    function testAllowsSafePriceUpdate() public {
+        vm.prank(address(0xdeadbeef));
+        // Set initial token price
+        assertionAdopter.setPrice(1 ether);
+
+        cl.addAssertion(
+            "PriceFeedAssertion",
+            address(assertionAdopter),
+            type(PriceFeedAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Update price within allowed range (5% increase)
+        vm.prank(address(0xdeadbeef));
+        cl.validate(
+            "PriceFeedAssertion",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(MockTokenPriceFeed.setPrice.selector, 1.05 ether)
+        );
+    }
+}
+
+contract BatchTokenPriceUpdates {
+    IPriceFeed public tokenPriceFeed;
+
+    constructor(address tokenPriceFeed_) {
+        tokenPriceFeed = IPriceFeed(tokenPriceFeed_);
+    }
+
+    fallback() external {
+        uint256 originalPrice = tokenPriceFeed.getPrice();
+
+        TempTokenPriceUpdater updater = new TempTokenPriceUpdater(address(tokenPriceFeed));
+
+        // Perform 10 token price updates (using realistic token/USD prices)
+        updater.setPrice(0.95 ether); // $0.95
+        updater.setPrice(1.05 ether); // $1.05
+        updater.setPrice(0.9 ether); // $0.90
+        updater.setPrice(1.1 ether); // $1.10
+        updater.setPrice(0.85 ether); // $0.85 -- price deviates too much, should trigger assertion
+        updater.setPrice(1.15 ether); // $1.15
+        updater.setPrice(0.9 ether); // $0.90
+        updater.setPrice(originalPrice); // Return to original price
+    }
+}
+
+contract TempTokenPriceUpdater {
+    IPriceFeed public tokenPriceFeed;
+
+    constructor(address tokenPriceFeed_) {
+        tokenPriceFeed = IPriceFeed(tokenPriceFeed_);
+    }
+
+    function setPrice(uint256 newPrice) external {
+        tokenPriceFeed.setPrice(newPrice);
+    }
+}

--- a/testdata/mock-protocol/assertions/test/SimpleLendingAssertion.t.sol
+++ b/testdata/mock-protocol/assertions/test/SimpleLendingAssertion.t.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {SimpleLendingAssertion} from "../src/SimpleLendingAssertion.a.sol";
+import {SimpleLending, MockPriceFeed, MockTokenPriceFeed, IERC20} from "../../src/SimpleLending.sol";
+import {Test} from "../../lib/credible-std/lib/forge-std/src/Test.sol";
+import {CredibleTest} from "../../lib/credible-std/src/CredibleTest.sol";
+import {ERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {console} from "../../lib/credible-std/lib/forge-std/src/console.sol";
+
+contract MockERC20 is ERC20 {
+    uint8 private _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+}
+
+contract TestSimpleLendingAssertion is CredibleTest, Test {
+    SimpleLending public assertionAdopter;
+    SimpleLendingAssertion public assertion;
+    MockPriceFeed public ethPriceFeed;
+    MockTokenPriceFeed public tokenPriceFeed;
+    IERC20 public borrowToken;
+
+    address testUser = address(0xBEEF);
+    uint256 constant INITIAL_ETH_PRICE = 2000e18; // $2000 per ETH
+    uint256 constant INITIAL_TOKEN_PRICE = 1e18; // $1 per token
+
+    function setUp() public {
+        // Deploy mock ERC20 token
+        MockERC20 token = new MockERC20("Test Token", "TEST", 18);
+        borrowToken = IERC20(address(token));
+
+        // Deploy price feeds
+        ethPriceFeed = new MockPriceFeed();
+        tokenPriceFeed = new MockTokenPriceFeed();
+
+        // Set initial prices
+        ethPriceFeed.setPrice(INITIAL_ETH_PRICE);
+        tokenPriceFeed.setPrice(INITIAL_TOKEN_PRICE);
+
+        // Deploy lending protocol
+        assertionAdopter = new SimpleLending(address(borrowToken), address(ethPriceFeed), address(tokenPriceFeed));
+
+        // Mint tokens to lending protocol for borrowing
+        token.mint(address(assertionAdopter), 1_000_000e18);
+
+        // Deploy assertion
+        assertion = new SimpleLendingAssertion(address(assertionAdopter));
+
+        // Setup test user
+        vm.deal(testUser, 10 ether);
+    }
+
+    function testAssertionCatchesUnsafeWithdrawal() public {
+        // User deposits 1 ETH as collateral
+        vm.startPrank(testUser);
+        assertionAdopter.deposit{value: 1 ether}();
+
+        // User borrows 1500 USDC (75% of collateral value at $2000/ETH)
+        assertionAdopter.borrow(1500e18); // Max borrow based on 75% collateral ratio
+
+        // Register the assertion
+        cl.addAssertion(
+            "collateralBalance",
+            address(assertionAdopter),
+            type(SimpleLendingAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Try to withdraw 0.5 ETH - this should fail the assertion
+        // because remaining collateral wouldn't cover the loan
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "collateralBalance",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 0.5 ether)
+        );
+        vm.stopPrank();
+    }
+
+    function testAssertionAllowsSafeWithdrawal() public {
+        // User deposits 1 ETH as collateral
+        vm.startPrank(testUser);
+        assertionAdopter.deposit{value: 1 ether}();
+
+        // User borrows only 500 USDC (25% of collateral value)
+        assertionAdopter.borrow(500e18);
+
+        // Register the assertion
+        cl.addAssertion(
+            "borrowedInvariant",
+            address(assertionAdopter),
+            type(SimpleLendingAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Try to withdraw 0.5 ETH - this should succeed
+        // because remaining collateral still covers the loan
+        cl.validate(
+            "borrowedInvariant",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 0.5 ether)
+        );
+
+        vm.stopPrank();
+    }
+
+    function testAssertionCatchesProtocolDrain() public {
+        // Setup multiple users depositing ETH
+        address[] memory users = new address[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            users[i] = address(uint160(0xbeef + i));
+            vm.deal(users[i], 2000 ether);
+
+            vm.prank(users[i]);
+            assertionAdopter.deposit{value: 2000 ether}();
+        }
+
+        // Total protocol collateral is now 10000 ETH
+        assertEq(assertionAdopter.totalCollateral(), 10000 ether);
+
+        // Register the assertion
+        cl.addAssertion(
+            "ethDrain",
+            address(assertionAdopter),
+            type(SimpleLendingAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Create attacker EOA
+        address attacker = address(0xdead);
+
+        // Try to drain using the buggy function
+        vm.prank(attacker);
+        vm.expectRevert("Assertions Reverted");
+        cl.validate(
+            "ethDrain",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.buggyWithdraw.selector, 8000 ether)
+        );
+    }
+
+    function testAssertionAllowsNormalWithdrawals() public {
+        // Setup multiple users depositing ETH
+        address[] memory users = new address[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            users[i] = address(uint160(0xbeef + i));
+            vm.deal(users[i], 2000 ether);
+
+            vm.prank(users[i]);
+            assertionAdopter.deposit{value: 2000 ether}();
+        }
+
+        // Register the assertion
+        cl.addAssertion(
+            "ethDrain",
+            address(assertionAdopter),
+            type(SimpleLendingAssertion).creationCode,
+            abi.encode(address(assertionAdopter))
+        );
+
+        // Normal withdrawal of 40% from one user should work
+        vm.prank(users[0]);
+        cl.validate(
+            "ethDrain",
+            address(assertionAdopter),
+            0,
+            abi.encodeWithSelector(assertionAdopter.withdraw.selector, 800 ether)
+        );
+    }
+}

--- a/testdata/mock-protocol/src/SimpleLending.sol
+++ b/testdata/mock-protocol/src/SimpleLending.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title SimpleLending
+/// @notice A basic lending protocol that allows users to borrow tokens against ETH collateral
+/// @dev This is a simplified implementation for demonstration purposes
+contract SimpleLending {
+    IERC20 public immutable borrowToken;
+
+    // Price feed interfaces for getting asset prices
+    IPriceFeed public immutable ethPriceFeed;
+    IPriceFeed public immutable tokenPriceFeed;
+
+    /// @notice Collateral ratio required (75% - can only borrow up to 75% of collateral value)
+    uint256 public constant COLLATERAL_RATIO = 75;
+
+    /// @notice Structure to track user's lending position
+    /// @param collateralAmount Amount of ETH deposited as collateral (in wei)
+    /// @param borrowedAmount Amount of tokens borrowed (in token's smallest unit)
+    struct Position {
+        uint256 collateralAmount;
+        uint256 borrowedAmount;
+    }
+
+    /// @notice Mapping of user addresses to their lending positions
+    mapping(address => Position) public positions;
+
+    /// @notice Total ETH collateral in the contract (in wei)
+    uint256 public totalCollateral;
+    /// @notice Total tokens borrowed from the contract
+    uint256 public totalBorrowed;
+
+    /// @notice Initializes the lending contract
+    /// @param _borrowToken Address of the ERC20 token that can be borrowed
+    /// @param _ethPriceFeed Address of the ETH price feed contract
+    /// @param _tokenPriceFeed Address of the token price feed contract
+    constructor(address _borrowToken, address _ethPriceFeed, address _tokenPriceFeed) {
+        borrowToken = IERC20(_borrowToken);
+        ethPriceFeed = IPriceFeed(_ethPriceFeed);
+        tokenPriceFeed = IPriceFeed(_tokenPriceFeed);
+    }
+
+    /// @notice Allows users to deposit ETH as collateral
+    /// @dev Emits no events currently (consider adding them)
+    function deposit() external payable {
+        require(msg.value > 0, "Must deposit ETH");
+
+        positions[msg.sender].collateralAmount += msg.value;
+        totalCollateral += msg.value;
+    }
+
+    /// @notice Allows users to borrow tokens against their ETH collateral
+    /// @param amount The amount of tokens to borrow
+    /// @dev WARNING: Price calculation doesn't consider decimals properly
+    function borrow(uint256 amount) external {
+        require(amount > 0, "Must borrow non-zero amount");
+
+        // Get current prices from oracles
+        uint256 ethPrice = ethPriceFeed.getPrice();
+        uint256 tokenPrice = tokenPriceFeed.getPrice();
+
+        Position storage position = positions[msg.sender];
+
+        // Calculate USD values for collateral and borrow amounts
+        uint256 collateralValue = position.collateralAmount * ethPrice;
+        uint256 newBorrowValue = (position.borrowedAmount + amount) * tokenPrice;
+
+        // Ensure new borrow amount maintains required collateral ratio
+        require(collateralValue * COLLATERAL_RATIO >= newBorrowValue * 100, "Would exceed collateral ratio");
+
+        position.borrowedAmount += amount;
+        totalBorrowed += amount;
+
+        require(borrowToken.transfer(msg.sender, amount), "Token transfer failed");
+    }
+
+    /// @notice Allows users to repay their borrowed tokens
+    /// @param amount The amount of tokens to repay
+    function repay(uint256 amount) external {
+        require(amount > 0, "Must repay non-zero amount");
+        Position storage position = positions[msg.sender];
+        require(position.borrowedAmount >= amount, "Cannot repay more than borrowed");
+
+        require(borrowToken.transferFrom(msg.sender, address(this), amount), "Token transfer failed");
+
+        position.borrowedAmount -= amount;
+        totalBorrowed -= amount;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                   THIS PART HAS BUGS, LET'S FIX THEM
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Allows users to withdraw their ETH collateral
+    /// @param amount The amount of ETH to withdraw (in wei)
+    /// @dev WARNING: Missing check for maintaining sufficient collateral ratio after withdrawal
+    function withdraw(uint256 amount) external {
+        require(amount > 0, "Must withdraw non-zero amount");
+        Position storage position = positions[msg.sender];
+        require(position.collateralAmount >= amount, "Insufficient collateral");
+
+        // Bug: No check if remaining collateral would be sufficient for current borrow
+        position.collateralAmount -= amount;
+        totalCollateral -= amount;
+
+        (bool success,) = msg.sender.call{value: amount}("");
+        require(success, "ETH transfer failed");
+    }
+
+    /// @notice A deliberately vulnerable withdrawal function used for testing assertions
+    /// @dev WARNING: This function is intentionally unsafe and should not be used in production
+    /// @dev It allows any caller to withdraw any amount of ETH without checks
+    /// @dev Known vulnerabilities:
+    ///      - No validation of caller's collateral balance
+    ///      - No validation of borrowed token ratio
+    ///      - Allows draining protocol's entire ETH balance
+    /// @param amount The amount of ETH to withdraw (in wei)
+    function buggyWithdraw(uint256 amount) external {
+        // No checks, just transfer ETH
+        payable(msg.sender).transfer(amount);
+        // Update state to simulate proper withdrawal
+        totalCollateral -= amount;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                   BUGGY PART OVER
+    //////////////////////////////////////////////////////////////*/
+}
+
+/// @title IPriceFeed
+/// @notice Interface for price feed oracles
+interface IPriceFeed {
+    /// @notice Gets the current price of an asset
+    /// @return The price with 18 decimals of precision
+    function getPrice() external view returns (uint256);
+    function setPrice(uint256 price) external;
+}
+
+/// @notice Mock price feed for ETH/USD
+contract MockPriceFeed is IPriceFeed {
+    uint256 public price;
+
+    function getPrice() public view returns (uint256) {
+        return price;
+    }
+
+    function setPrice(uint256 _price) external {
+        price = _price;
+    }
+}
+
+/// @notice Mock price feed for Token/USD
+contract MockTokenPriceFeed is IPriceFeed {
+    uint256 public price;
+
+    function getPrice() public view returns (uint256) {
+        return price;
+    }
+
+    function setPrice(uint256 _price) external {
+        price = _price;
+    }
+}


### PR DESCRIPTION
When I prepared the Denver workshop I created a simple lending platform with a couple of bugs in it that could be used for writing assertions. 

I thought it would be good to add it in the testdata folder here in order to showcase more of the cheatcodes we don't yet show here.

This PR also makes the tests for Ownable pass