### PR TITLE
fix: call correct authed endpoint for submit

### DIFF
--- a/crates/core/src/assertion_da.rs
+++ b/crates/core/src/assertion_da.rs
@@ -69,7 +69,7 @@ impl DASubmitArgs {
         config.add_assertion_for_submission(
             self.assertion.clone(),
             result.id.to_string(),
-            result.signature.to_string()
+            result.signature.to_string(),
         );
         // Finish spinner with success message
         spinner.finish_with_message("✅ Assertion successfully submitted!");
@@ -78,11 +78,15 @@ impl DASubmitArgs {
         println!("\n\n{}", "Assertion Information".bold().green());
         println!("{}", "===================".green());
         println!("{}", config.assertions_for_submission.last().unwrap());
-        
+
         // Display next steps with highlighted command
         println!("\n{}", "Next Steps:".bold());
         println!("Submit this assertion to a project with:");
-        println!("  {} submit -a {} -p <project_name>", "pcl".cyan().bold(), self.assertion.cyan());
+        println!(
+            "  {} submit -a {} -p <project_name>",
+            "pcl".cyan().bold(),
+            self.assertion.cyan()
+        );
         println!("Visit the Credible Layer DApp to link the assertion on-chain and enforce it:");
         println!("  {}", "https://dapp.credible.layer".cyan().bold());
         Ok(())

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -43,8 +43,12 @@ impl CliConfig {
         Self::read_from_file_at_dir(Self::get_config_dir())
     }
 
-    pub fn add_assertion_for_submission(&mut self, assertion_contract: String, assertion_id: String, signature: String)
-    {
+    pub fn add_assertion_for_submission(
+        &mut self,
+        assertion_contract: String,
+        assertion_id: String,
+        signature: String,
+    ) {
         self.assertions_for_submission.push(AssertionForSubmission {
             assertion_contract,
             assertion_id,


### PR DESCRIPTION
The previous /submit api call was incorrect. 

## Added

- corrected endpoint (/projects/:project_id/submitted-assertions)
- authorization header with access token from `pcl auth login` step
- corrected request body type