### PR TITLE
fix: proper handling of different assertion input options

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,2 +1,37 @@
 pub mod args;
 pub mod utils;
+
+#[derive(Clone)]
+pub struct Assertion {
+    file_name: Option<String>,
+    contract_name: String,
+}
+
+impl Assertion {
+    const SUPPORTED_EXTENSIONS: &'static [&'static str] = &[".a.sol", ".sol"];
+
+    pub fn new(file_name: Option<String>, contract_name: String) -> Self {
+        Self {
+            file_name,
+            contract_name,
+        }
+    }
+
+    pub fn get_paths(&self) -> Vec<String> {
+        match &self.file_name {
+            Some(file_name) => vec![file_name.clone()],
+            None => {
+                let mut file_names = Vec::new();
+                for ext in Self::SUPPORTED_EXTENSIONS {
+                    let path = format!("{}{}", self.contract_name, ext);
+                    file_names.push(path);
+                }
+                file_names
+            }
+        }
+    }
+
+    pub fn contract_name(&self) -> &String {
+        &self.contract_name
+    }
+}

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -1,62 +1,57 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+use crate::Assertion;
+
+#[derive(Debug)]
+pub struct BuildInfo {
+    pub compiler_version: String,
+    pub compilation_target: String,
+    pub bytecode: String,
+}
 
 /// Reads a contract artifact
 /// Input can be specified in two patterns
-/// 1. ${file_name.sol}:${contract_name}
+/// 1. ${file_name[.sol, .a.sol]}:${contract_name}
 /// 2. ${contract_name} (file_name is assumed to be the same as contract_name, with .sol extension)
 ///
 /// out_dir is the output directory of the build artifact
-pub fn read_artifact(input: &str, out_dir: &Path) -> serde_json::Value {
-    let mut parts = input.split(':');
-
-    let contract_name;
-    let file_name;
-    if parts.clone().count() > 1 {
-        // Extract file name from the first part of the input
-        file_name = parts.next().expect("Failed to read file name").to_string();
-        // Extract contract name from the second part of the input
-        contract_name = parts.next().expect("Failed to read contract name");
-    } else {
-        // If no colon separator, assume contract name is the same as file name
-        contract_name = parts.next().expect("Failed to read contract name");
-        // Create a path with .sol extension for the file name
-        let mut path = PathBuf::from(contract_name);
-        path.set_extension("sol");
-        file_name = path.to_string_lossy().to_string();
+pub fn read_artifact(input: &Assertion, out_dir: &Path) -> serde_json::Value {
+    let file_names = input.get_paths();
+    // Try each file name until we find one that exists
+    for file_name in &file_names {
+        let path = out_dir.join(format!("{}/{}.json", file_name, input.contract_name()));
+        if path.exists() {
+            let file = std::fs::File::open(&path).expect("Failed to open file");
+            return serde_json::from_reader(file).expect("Failed to parse JSON");
+        }
     }
-
-    let new_path = out_dir.join(format!("{}/{}.json", file_name, contract_name));
-
-    let file = std::fs::File::open(new_path).expect("Failed to open file");
-    serde_json::from_reader(file).expect("Failed to parse JSON")
+    panic!("Failed to find artifact for {}", input.contract_name());
 }
 
 /// Reads deployment bytecode from a contract artifact
 /// Input can be specified in two patterns
-/// 1. ${file_name.sol}:${contract_name}
+/// 1. ${file_name[.sol, .a.sol]}:${contract_name}
 /// 2. ${contract_name} (file_name is assumed to be the same as contract_name, with .sol extension)
 ///
 /// out_dir is the output directory of the build artifact
-pub fn bytecode(input: &str, out_dir: &Path) -> String {
-    let value = read_artifact(input, out_dir);
-    let bytecode = value["bytecode"]["object"]
+pub fn bytecode(artifact: &serde_json::Value) -> String {
+    let bytecode = artifact["bytecode"]["object"]
         .as_str()
         .expect("Failed to read bytecode");
     bytecode.to_string()
 }
 
-pub fn compilation_target(input: &str, out_dir: &Path) -> String {
-    let value = read_artifact(input, out_dir);
+pub fn compilation_target(input: &Assertion, artifact: &serde_json::Value) -> String {
     // The compilationTarget is a map with a single key-value pair where the key is the file path
     // and the value is the contract name. We need to extract the file path (key).
-    let compilation_target = value["metadata"]["settings"]["compilationTarget"]
+    let compilation_target = artifact["metadata"]["settings"]["compilationTarget"]
         .as_object()
         .expect("Failed to read compilation target as object");
     // Get the compilation target of the contract with name contract_name
     compilation_target
         .iter()
         .find_map(|(key, value)| {
-            if value.as_str() == Some(input) {
+            if value.as_str() == Some(input.contract_name()) {
                 Some(key.to_string())
             } else {
                 None
@@ -65,10 +60,18 @@ pub fn compilation_target(input: &str, out_dir: &Path) -> String {
         .expect("Failed to find contract in compilation target")
 }
 
-pub fn compiler_version(input: &str, out_dir: &Path) -> String {
-    let value = read_artifact(input, out_dir);
-    let compiler_version = value["metadata"]["compiler"]["version"]
+pub fn compiler_version(artifact: &serde_json::Value) -> String {
+    let compiler_version = artifact["metadata"]["compiler"]["version"]
         .as_str()
         .expect("failed to read compiler version");
     compiler_version.to_string()
+}
+
+pub fn get_build_info(input: &Assertion, out_dir: &Path) -> BuildInfo {
+    let artifact = read_artifact(input, out_dir);
+    BuildInfo {
+        compiler_version: compiler_version(&artifact),
+        compilation_target: compilation_target(input, &artifact),
+        bytecode: bytecode(&artifact),
+    }
 }

--- a/crates/core/src/assertion_da.rs
+++ b/crates/core/src/assertion_da.rs
@@ -1,10 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
-use pcl_common::{
-    args::CliArgs,
-    utils::{compilation_target, compiler_version},
-};
+use pcl_common::{args::CliArgs, utils::get_build_info, Assertion};
 use pcl_phoundry::build::BuildArgs;
 use tokio::time::Duration;
 
@@ -23,7 +20,28 @@ pub struct DASubmitArgs {
     #[clap(long, env = "PCL_DA_URL", default_value = "http://localhost:5001")]
     url: String,
     /// Name of the assertion contract to submit
-    assertion: String,
+    #[clap(value_parser = parse_assertion)]
+    assertion: Assertion,
+}
+
+fn parse_assertion(s: &str) -> Result<Assertion, String> {
+    let parts = s.split(':').collect::<Vec<&str>>();
+
+    if parts.len() == 1 {
+        return Ok(Assertion::new(None, parts[0].to_string()));
+    }
+
+    if parts.len() == 2 {
+        return Ok(Assertion::new(
+            Some(parts[0].to_string()),
+            parts[1].to_string(),
+        ));
+    }
+
+    Err(
+        "Assertion must be in the format <file_name>:<contract_name> or <contract_name>"
+            .to_string(),
+    )
 }
 
 impl DASubmitArgs {
@@ -33,24 +51,25 @@ impl DASubmitArgs {
         config: &mut CliConfig,
     ) -> Result<(), DaSubmitError> {
         let build_args = BuildArgs {
-            assertions: vec![self.assertion.clone()],
+            assertions: vec![self.assertion.contract_name().clone()],
         };
 
         let _result = build_args.run(cli_args)?;
 
         let out_dir = cli_args.out_dir();
-        let relative_path = compilation_target(&self.assertion, &out_dir);
+        let build_info = get_build_info(&self.assertion, &out_dir);
         let mut full_path = cli_args.root_dir();
-        full_path.push(relative_path);
+        full_path.push(build_info.compilation_target);
 
         let flatten_contract = build_args.get_flattened_source(&full_path, cli_args)?;
-        let compiler_version = compiler_version(&self.assertion, &out_dir)
+        let compiler_version = build_info
+            .compiler_version
             .split('+')
             .next()
             .unwrap_or_default()
             .to_string();
 
-        // Create a spinner to show progress while submitting
+        // Create a spinner to show progress w  hile submitting
         let spinner = ProgressBar::new_spinner();
         spinner.set_style(
             ProgressStyle::default_spinner()
@@ -63,11 +82,15 @@ impl DASubmitArgs {
 
         // Submit the assertion
         let result = DaClient::new(&self.url)?
-            .submit_assertion(self.assertion.clone(), flatten_contract, compiler_version)
+            .submit_assertion(
+                self.assertion.contract_name().to_string(),
+                flatten_contract,
+                compiler_version,
+            )
             .await?;
 
         config.add_assertion_for_submission(
-            self.assertion.clone(),
+            self.assertion.contract_name().to_string(),
             result.id.to_string(),
             result.signature.to_string(),
         );
@@ -85,7 +108,7 @@ impl DASubmitArgs {
         println!(
             "  {} submit -a {} -p <project_name>",
             "pcl".cyan().bold(),
-            self.assertion.cyan()
+            self.assertion.contract_name().cyan()
         );
         println!("Visit the Credible Layer DApp to link the assertion on-chain and enforce it:");
         println!("  {}", "https://dapp.credible.layer".cyan().bold());


### PR DESCRIPTION
Properly handles different varieties of assertion argument. 

Basically can be: 
- <contract_name>
- <file_name>:<contract_name>

The PR fixes 3 issues: 

- compilation target was comparing against raw input but needs to compare to <contract_name>
- if only contract name provided it checks for [.sol or .a.sol] file extension
- DA request body contained raw input instead of <contract_name>

The raw input is now parsed and stored into a proper struct which unifies the handling afterwards.


Additionally it optimizes: 

- only read the build artifact once, and extract necessary information (before it was read and deserialized whenever some information was needed)


One question left @odyslam 
When only the contract name is passed, should we allow looking for multiple suffixes or should we enforce looking for `.a.sol` (which will enforce using `.a.sol` as file extensions for assertions)

Currently, the algorithm will look for both `.a.sol` and `.sol` files with priority in that order.
