### PR TITLE
feat: add success message to DappSubmit

### DIFF
--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -112,8 +112,9 @@ impl DappSubmitArgs {
         self.submit_assertion(project, &assertions, config).await?;
 
         println!(
-            "Successfully submitted {} assertions to project {}",
+            "Successfully submitted {} assertion{} to project {}",
             assertions.len(),
+            if assertions.len() > 1 { "s" } else { "" },
             project.project_name
         );
 

--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -111,6 +111,12 @@ impl DappSubmitArgs {
 
         self.submit_assertion(project, &assertions, config).await?;
 
+        println!(
+            "Successfully submitted {} assertions to project {}",
+            assertions.len(),
+            project.project_name
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
Adds a success message to DappSubmit command so it no longer silently succeeds.