### PR TITLE
fix: better error handling in dapp submission

### DIFF
--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -111,10 +111,7 @@ impl DappSubmitArgs {
     }
 
     /// Abstracted function for selecting a project
-    fn select_project<'a>(
-        &self,
-        projects: &'a Vec<Project>,
-    ) -> Result<&'a Project, DappSubmitError> {
+    fn select_project<'a>(&self, projects: &'a [Project]) -> Result<&'a Project, DappSubmitError> {
         if projects.is_empty() {
             return Err(DappSubmitError::NoProjectsFound);
         }

--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -84,7 +84,7 @@ impl DappSubmitArgs {
         let keys: Vec<AssertionKey> = config
             .assertions_for_submission
             .keys()
-            .map(|k| k.clone())
+            .cloned()
             .collect();
 
         let assertion_keys = self.select_assertions(keys.as_slice())?;

--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -81,11 +81,7 @@ impl DappSubmitArgs {
         let projects = self.get_projects(config).await?;
 
         let project = self.select_project(&projects)?;
-        let keys: Vec<AssertionKey> = config
-            .assertions_for_submission
-            .keys()
-            .cloned()
-            .collect();
+        let keys: Vec<AssertionKey> = config.assertions_for_submission.keys().cloned().collect();
 
         let assertion_keys = self.select_assertions(keys.as_slice())?;
 

--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -132,7 +132,7 @@ impl DappSubmitArgs {
     /// Abstracted function for selecting assertions
     fn select_assertions(
         &self,
-        assertion_keys_for_submission: &Vec<AssertionKey>,
+        assertion_keys_for_submission: &[AssertionKey],
     ) -> Result<Vec<String>, DappSubmitError> {
         if assertion_keys_for_submission.is_empty() {
             return Err(DappSubmitError::NoStoredAssertions);
@@ -154,8 +154,6 @@ impl DappSubmitArgs {
             "Select an assertion to submit:".to_string(),
         )
     }
-
-    /// Submits selected assertions to the specified project
     ///
     /// # Arguments
     /// * `project` - Target project for submission

--- a/crates/core/src/assertion_submission.rs
+++ b/crates/core/src/assertion_submission.rs
@@ -81,13 +81,14 @@ impl DappSubmitArgs {
         let projects = self.get_projects(config).await?;
 
         let project = self.select_project(&projects)?;
-        let assertion_keys = self.select_assertions(
-            &config
-                .assertions_for_submission
-                .clone()
-                .into_keys()
-                .collect(),
-        )?;
+        let keys: Vec<AssertionKey> = config
+            .assertions_for_submission
+            .keys()
+            .map(|k| k.clone())
+            .collect();
+
+        let assertion_keys = self.select_assertions(keys.as_slice())?;
+
         let mut assertions = vec![];
         for key in assertion_keys {
             let assertion = config
@@ -312,7 +313,7 @@ mod tests {
             assertion_keys: None,
         };
 
-        let empty_assertions = vec![];
+        let empty_assertions = [];
         let result = args.select_assertions(&empty_assertions);
 
         assert!(result.is_err());

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -35,6 +35,21 @@ pub struct AssertionKey {
     pub assertion_name: String,
     pub constructor_args: Vec<String>,
 }
+impl AssertionKey {
+    /// Create a new assertion key
+    ///
+    /// # Arguments
+    /// * `assertion_name` - The name of the assertion
+    /// * `constructor_args` - The constructor arguments for the assertion
+    ///
+    pub fn new(assertion_name: String, constructor_args: Vec<String>) -> Self {
+        Self {
+            assertion_name,
+            constructor_args,
+        }
+    }
+}
+
 impl fmt::Display for AssertionKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.assertion_name)?;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -40,9 +40,13 @@ pub enum DappSubmitError {
     #[error("No auth token found, please run `pcl auth` first")]
     NoAuthToken,
 
-    /// Error when user cancels the project selection process
-    #[error("Project selection cancelled")]
-    ProjectSelectionCancelled,
+    /// Error during project selection process
+    #[error("Project selection failed: {0}")]
+    ProjectSelectionFailed(#[from] inquire::InquireError),
+
+    /// Error when no projects are found for the authenticated user
+    #[error("No projects found for the authenticated user.\nPlease run `pcl project new` to create one.")]
+    NoProjectsFound,
 
     /// Error when connection to the dApp API fails
     #[error("Failed to connect to the dApp API")]
@@ -52,9 +56,13 @@ pub enum DappSubmitError {
     #[error("Submission failed: {0}")]
     SubmissionFailed(String),
 
-    /// Error
-    #[error("Could not find stored assertion {0} in the config. Please run `pcl store` first.")]
+    /// Error when could not find stored assertion
+    #[error("Could not find stored assertion {0} in the config.\nPlease run `pcl store` first.")]
     CouldNotFindStoredAssertion(String),
+
+    /// Error when no stored assertions are found
+    #[error("No stored assertions found.\nPlease run `pcl store` first to store some assertions.")]
+    NoStoredAssertions,
 }
 
 /// Errors that can occur during configuration operations

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -45,7 +45,7 @@ pub enum DappSubmitError {
     ProjectSelectionFailed(#[from] inquire::InquireError),
 
     /// Error when no projects are found for the authenticated user
-    #[error("No projects found for the authenticated user.\nPlease run `pcl project new` to create one.")]
+    #[error("No projects found for the authenticated user.\nPlease run `pcl project new` or head to https://dapp.phylax.systems to create one.")]
     NoProjectsFound,
 
     /// Error when connection to the dApp API fails

--- a/testdata/mock-protocol/.gitignore
+++ b/testdata/mock-protocol/.gitignore
@@ -6,6 +6,7 @@ out/
 !/broadcast
 /broadcast/*/31337/
 /broadcast/**/dry-run/
+/broadcast/**/
 
 # Docs
 docs/


### PR DESCRIPTION
Changes to `pcl submit`:
- Add typed error to suggest `pcl store` when there are no stored assertions.
- Add typed error to suggest `pcl projects new` when there are no projects for the authorized user.
- Pass through other errors with Select component.
- Refactor selection for ease of unit testing