### PR TITLE
fix: make cargo install locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7542,7 +7542,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -7559,7 +7559,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "clap",
  "serde_json",
@@ -7568,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "alloy-primitives",
  "assertion-da-client 0.1.0 (git+ssh://git@github.com/phylaxsystems/assertion-da.git?rev=cc1b26e)",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "0.0.1"
+version = "0.0.4"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = '2'
 exclude = [".github", "phoundry/"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.4"
 authors = ["Phylax Systems"]
 edition = "2021"
 rust-version = "1.80"

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 
 # Install the binary
 install:
-	cargo install --verbose --path bin/pcl
- 
+	cargo install --locked --verbose --path bin/pcl
+
 # Build the contract mocks and run the rust tests
 test:
 	cargo nextest run --all-features --workspace --locked 


### PR DESCRIPTION
- During cargo install without `--locked`, cargo will attempt to use a non-compatible version of `solar-parse` causing it to fail:
```
error: could not compile `solar-parse` (lib) due to 6 previous errors
```
- This pr adds `locked` to the makefile fixing the above