### PR TITLE
fix: update authorization header format in  command

### DIFF
--- a/crates/core/src/assertion_da.rs
+++ b/crates/core/src/assertion_da.rs
@@ -176,7 +176,9 @@ impl DaStoreArgs {
     /// * `Result<DaClient, DaClientError>` - The configured client or error
     fn create_da_client(&self, config: &CliConfig) -> Result<DaClient, DaClientError> {
         match &config.auth {
-            Some(auth) => DaClient::new_with_auth(&self.url, &format!("Bearer {}", auth.access_token)),
+            Some(auth) => {
+                DaClient::new_with_auth(&self.url, &format!("Bearer {}", auth.access_token))
+            }
             None => DaClient::new(&self.url),
         }
     }

--- a/crates/core/src/assertion_da.rs
+++ b/crates/core/src/assertion_da.rs
@@ -176,7 +176,7 @@ impl DaStoreArgs {
     /// * `Result<DaClient, DaClientError>` - The configured client or error
     fn create_da_client(&self, config: &CliConfig) -> Result<DaClient, DaClientError> {
         match &config.auth {
-            Some(auth) => DaClient::new_with_auth(&self.url, &auth.access_token),
+            Some(auth) => DaClient::new_with_auth(&self.url, &format!("Bearer {}", auth.access_token)),
             None => DaClient::new(&self.url),
         }
     }


### PR DESCRIPTION
Changes format of the `Authorization` header in the `store` command to `Bearer <access_token>`