### PR TITLE
ci(release): require and use SSH_PRIVATE_KEY for build-pcl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,9 @@ jobs:
       package: "pcl"
       cargo-features: "full"
       enable-sccache: true
+      requires-private-deps: true
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   release-github:
     needs: [create-tag, build-pcl]


### PR DESCRIPTION
## Summary

Enables \`requires-private-deps: true\` on the \`build-pcl\` job in the release workflow and forwards the \`SSH_PRIVATE_KEY\` secret to the shared \`rust-build-binary.yaml\` workflow.

## Motivation

- The release builds with \`--features full\`, which pulls git deps that may require SSH auth in the future
- Reuses the existing \`SSH_PRIVATE_KEY\` secret instead of adding a new one
- Together with the upstream preflight check (phylaxsystems/actions#79), this fails the release fast if the deploy key is misconfigured

## Depends on

- phylaxsystems/actions#79 — adds the preflight SSH verification step

## Test plan

- [ ] Release workflow still completes when \`SSH_PRIVATE_KEY\` is valid
- [ ] Release workflow fails clearly when \`SSH_PRIVATE_KEY\` is missing or invalid