### PR TITLE
chore: release 1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -7370,7 +7370,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "clap",
  "serde_json",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -7410,7 +7410,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"


### PR DESCRIPTION
## Summary

Bumps the workspace version to \`1.3.2\`.

Merging triggers the release workflow, which will tag \`1.3.2\`, build binaries with \`--features full\` (via SSH key wiring merged in #81), create a GitHub release, and update the homebrew-pcl formula.

## Test plan

- [ ] Preflight SSH check passes (confirms \`SSH_PRIVATE_KEY\` is a valid GitHub SSH key)
- [ ] All 3 platform builds succeed
- [ ] \`brew upgrade phylax\` installs 1.3.2