### PR TITLE
Reduce dependency security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,18 @@ env:
   RUST_NIGHTLY_VERSION: "nightly-2026-01-07"
 
 jobs:
+  runner-git-config:
+    name: Runner Git Config Preflight
+    runs-on: phylax-self-hosted
+    steps:
+      - name: Remove leaked GitHub SSH rewrites
+        run: |
+          git config --global --unset-all 'url.git@github.com:.insteadOf' || true
+          git config --global --unset-all 'url.ssh://git@github.com/.insteadOf' || true
+
   rust-base:
     name: Rust Test & Lint
+    needs: runner-git-config
     uses: phylaxsystems/actions/.github/workflows/rust-base.yaml@main
     with:
       runner: "phylax-self-hosted"
@@ -59,11 +69,39 @@ jobs:
       deny-checks: "advisories"
       deny-preinstalled: true
 
-  agent-smoke:
-    name: Agent CLI Smoke
+  release-feature-check:
+    name: Release Feature Check
+    needs: runner-git-config
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: phylax-self-hosted
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
+      GIT_CONFIG_GLOBAL: /tmp/pcl-release-feature-${{ github.run_id }}-${{ github.run_attempt }}.gitconfig
+      RUSTC_WRAPPER: ""
+      SCCACHE_DISABLE: "1"
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Configure SSH for private dependencies
+        if: env.SSH_PRIVATE_KEY != ''
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
+      - name: Prefer SSH for GitHub dependencies
+        if: env.SSH_PRIVATE_KEY != ''
+        run: git config --file "$GIT_CONFIG_GLOBAL" url."git@github.com:".insteadOf "https://github.com/"
+      - name: Install Rust toolchain
+        run: rustup toolchain install "$RUST_NIGHTLY_VERSION" --profile minimal --no-self-update
+      - name: Check release feature set
+        run: make full-check
+
+  agent-smoke:
+    name: Agent CLI Smoke
+    needs: [runner-git-config, release-feature-check]
+    runs-on: phylax-self-hosted
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      GIT_CONFIG_GLOBAL: /tmp/pcl-agent-smoke-${{ github.run_id }}-${{ github.run_attempt }}.gitconfig
       PCL_AUTH_NO_BROWSER: "1"
       RUSTC_WRAPPER: ""
       SCCACHE_DISABLE: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes should be recorded here.
 
 ## Unreleased
 
+## 1.5.0 - 2026-05-08
+
+- Added `pcl apply --dry-run` to build and verify release payloads from `credible.toml` without calling the API.
+- Fixed full-feature release builds for local assertion verification.
+- Reduced dependency advisory exposure by replacing the `vergen-gix` build dependency and refreshing patched transitive dependencies.
+
 ## 1.4.0 - 2026-05-06
 
 - Added agent-oriented CLI discovery, schemas, JSON/TOON envelopes, resumable jobs, and artifact surfaces.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -540,7 +540,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonwebtoken",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "strum 0.27.2",
 ]
@@ -638,7 +638,7 @@ dependencies = [
  "coins-bip39",
  "eth-keystore",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -955,15 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1240,7 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1250,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1576,7 +1567,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1838,39 +1829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,7 +1884,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2048,7 +2006,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2063,15 +2021,6 @@ dependencies = [
  "strsim",
  "textwrap",
  "zeroize",
-]
-
-[[package]]
-name = "clru"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2110,7 +2059,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2",
  "thiserror 1.0.69",
 ]
@@ -2449,7 +2398,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 0.38.44",
- "signal-hook 0.3.18",
+ "signal-hook",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2467,7 +2416,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 1.1.4",
- "signal-hook 0.3.18",
+ "signal-hook",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2854,7 +2803,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3125,7 +3074,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "scrypt",
  "serde",
  "serde_json",
@@ -3228,16 +3177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,17 +3235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,7 +3247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3338,7 +3266,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs 0.6.3",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3793,7 +3721,7 @@ dependencies = [
  "tower",
  "tracing",
  "url",
- "vergen 8.3.2",
+ "vergen",
  "walkdir",
  "yansi",
 ]
@@ -4457,745 +4385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "gix"
-version = "0.77.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8284d86a2f5c0987fbf7219a128815cc04af5a18f5fd7eec6a76d83c2b78cc"
-dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-date",
- "gix-diff",
- "gix-dir",
- "gix-discover",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-pathspec",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-status",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "parking_lot",
- "signal-hook 0.3.18",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c345528d405eab51d20f505f5fe1a4680973953694e0292c6bbe97827daa55c4"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-utils",
- "itoa",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dabf8a50f1558c3a55d978440c7c4f22f87ac897bef03b4edbc96f6115966"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9c425730a654835351e6da8c3c69ba1804f8b8d4e96d027254151138d5c64"
-dependencies = [
- "bstr",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdcba8048045baf15225daf949d597c3e6183d130245e22a7fbd27084abe63a"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-hash",
- "memmap2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58e2ff8eef96b71f2c5e260f02ca0475caff374027c5cc5a29bda69fac67404"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "memchr",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-path",
- "libc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4a31bab8159e233094fa70d2e5fd3ec6f19e593f67e6ae01281daa48f8d8e7"
-dependencies = [
- "bstr",
- "itoa",
- "jiff",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3506936e63ce14cd54b5f28ed06c8e43b92ef9f41c2238cc0bc271a9259b4e90"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-command",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "imara-diff",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-dir"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9fad32d2eb8b0129850874246569e801b6d5877e0c41356c23e9e2501e06"
-dependencies = [
- "bstr",
- "gix-discover",
- "gix-fs",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-trace",
- "gix-utils",
- "gix-worktree",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ce096dc132533802a09d6fd5d4008858f2038341dfe2e69e0d0239edb359de"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs",
- "gix-hash",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.45.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56aad357ae016449434705033df644ac6253dfcf1281aad3af3af9e907560d1"
-dependencies = [
- "crc32fast",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "once_cell",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs 0.5.5",
-]
-
-[[package]]
-name = "gix-filter"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c02464962482570c1f94ad451a608c4391514f803e8074662d02c5629a25dc"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "gix-utils",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785b9c499e46bc78d7b81c148c21b3fca18655379ee729a856ed19ce50d359ec"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153930f42ccdab8a3306b1027cd524879f6a8996cd0c474d18b0e56cae7714d"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
-dependencies = [
- "gix-hash",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa727fdf54fd9fb53fa3fbb1a5c17172d3073e8e336bf155f3cac3e25b81b21"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-trace",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea6d3e9e11647ba49f441dea0782494cc6d2875ff43fa4ad9094e6957f42051"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate",
- "hashbrown 0.16.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix 1.1.4",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-lock"
-version = "20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115268ae5e3b3b7bc7fc77260eecee05acca458e45318ca45d35467fa81a3ac5"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363d6a879c52e4890180e0ffa7d8c9a364fd0b7e807caa368e860b80e8d0bc81"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165a907df369a12ed4330faf8baf7ae597aadb08cfacb4ed8649f93d90bcc0c5"
-dependencies = [
- "arc-swap",
- "gix-date",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.64.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04a73d5ab07ea0faae55e2c0ae6f24e36e365ac8ce140394dee3a2c89cd4366"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "memmap2",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.10.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c5dfd068789442c5709e702ef42d851765f2c09a11bf0a13749d24363f4d07"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-ref",
- "gix-shallow",
- "gix-transport",
- "gix-utils",
- "maybe-async",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
-dependencies = [
- "bstr",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb33aa97006e37e9e83fde233569a66b02ed16fd4b0406cdf35834b06cf8a63"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.18",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbba6ae5389f4021f73a2d62a4195aace7db1e8bb684b25521d3d685f57da02"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91898c83b18c635696f7355d171cfa74a52f38022ff89581f567768935ebc4c8"
-dependencies = [
- "bitflags 2.11.1",
- "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d063699278485016863d0d2bb0db7609fd2e8ba9a89379717bf06fd96949eb2"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
-dependencies = [
- "bitflags 2.11.1",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1c467fb9f7ec1d33613c2ea5482de514bcb84b8222a793cdc4c71955832356"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-lock",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-status"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0d94c685a831c679ca5454c22f350e8c233f50dcf377ca00d858bcba9696d2"
-dependencies = [
- "bstr",
- "filetime",
- "gix-diff",
- "gix-dir",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-worktree",
- "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efee2a61198413d80de10028aa507344537827d776ade781760130721bec2419"
-dependencies = [
- "bstr",
- "gix-config",
- "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad89218e74850f42d364ed3877c7291f0474c8533502df91bb877ecc5cb0dd40"
-dependencies = [
- "dashmap",
- "gix-fs",
- "libc",
- "parking_lot",
- "signal-hook 0.4.4",
- "signal-hook-registry",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
-
-[[package]]
-name = "gix-transport"
-version = "0.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d4ed02a2ebe771a26111896ecda0b98b58ed35e1d9c0ccf07251c1abb4918d"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d052b83d1d1744be95ac6448ac02f95f370a8f6720e466be9ce57146e39f5280"
-dependencies = [
- "bitflags 2.11.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff1996dfb9430b3699d89224c674169c1ae355eacc52bf30a03c0b8bffe73d9"
-dependencies = [
- "bstr",
- "gix-features",
- "gix-path",
- "percent-encoding",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
-dependencies = [
- "bstr",
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
-dependencies = [
- "bstr",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfb7ce8cdbfe06117d335d1ad329351468d20331e0aafd108ceb647c1326aca"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-validate",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,15 +4471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5354,16 +4534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -5611,7 +4781,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5752,15 +4922,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -6049,12 +5210,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
- "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6066,21 +5225,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
 ]
 
 [[package]]
@@ -6113,7 +5257,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6260,15 +5404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6329,10 +5464,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -6474,17 +5606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "mdbook"
 version = "0.4.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6518,15 +5639,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -6777,21 +5889,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6964,15 +6067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6986,16 +6080,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "objc2",
-]
-
-[[package]]
-name = "objc2-io-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
-dependencies = [
- "libc",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -7180,15 +6264,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -7212,9 +6295,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -7304,9 +6387,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7359,7 +6442,6 @@ dependencies = [
 name = "pcl"
 version = "1.4.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
  "clap_complete",
@@ -7371,7 +6453,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "vergen-gix",
 ]
 
 [[package]]
@@ -7584,7 +6665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7688,12 +6769,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -7844,16 +6919,7 @@ dependencies = [
  "nix 0.31.2",
  "tokio",
  "tracing",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "prodash"
-version = "30.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
-dependencies = [
- "parking_lot",
+ "windows",
 ]
 
 [[package]]
@@ -8127,9 +7193,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -8282,15 +7348,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -8731,13 +7788,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8811,7 +7868,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand 0.9.4",
  "rlp",
  "ruint-macro",
@@ -8848,7 +7905,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -8885,7 +7942,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8968,9 +8025,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9134,7 +8191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -9418,16 +8475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest 0.10.7",
- "sha1",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9499,16 +8546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9516,7 +8553,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook 0.3.18",
+ "signal-hook",
 ]
 
 [[package]]
@@ -10134,20 +9171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10223,7 +9246,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10233,7 +9256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10923,12 +9946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10939,15 +9956,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -11112,49 +10120,6 @@ dependencies = [
  "cfg-if",
  "rustversion",
  "time",
-]
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
- "rustc_version 0.4.1",
- "rustversion",
- "sysinfo",
- "time",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gix"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24433912be6b84c6f8f41907edfaad852deaa666f59da5f46621b0ef58b644f0"
-dependencies = [
- "anyhow",
- "derive_builder",
- "gix",
- "rustversion",
- "time",
- "vergen 9.1.0",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
 ]
 
 [[package]]
@@ -11359,7 +10324,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11520,36 +10485,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -11558,20 +10501,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -11582,20 +10512,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11604,9 +10523,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -11633,25 +10552,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -11659,8 +10562,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -11669,18 +10572,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -11689,16 +10583,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -11707,7 +10592,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11752,7 +10637,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11792,7 +10677,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -11805,20 +10690,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -12255,12 +11131,6 @@ dependencies = [
  "thiserror 2.0.18",
  "zip",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zlib-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6440,7 +6440,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -6465,7 +6465,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -6499,7 +6499,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.4.1"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-.PHONY: ci fmt-check clippy test doc diff-check agent-smoke audit regenerate regenerate-dev
+.PHONY: ci fmt-check clippy full-check test doc diff-check agent-smoke audit regenerate regenerate-dev
 
-ci: fmt-check clippy test doc agent-smoke diff-check
+ci: fmt-check clippy full-check test doc agent-smoke diff-check
 
 fmt-check:
 	cargo fmt --all -- --check
 
 clippy:
 	cargo +nightly-2026-01-07 clippy --all-targets --workspace --locked --profile dev -- -D warnings -D clippy::pedantic
+
+full-check:
+	cargo check --locked --workspace --all-targets --features full
+	PCL_AUTH_NO_BROWSER=1 cargo test -q -p pcl --features full --test verify_cli
 
 test:
 	PCL_AUTH_NO_BROWSER=1 cargo test -q --workspace --all-targets

--- a/crates/pcl/cli/Cargo.toml
+++ b/crates/pcl/cli/Cargo.toml
@@ -30,5 +30,3 @@ credible = ["pcl-phoundry/credible", "pcl-core/credible"]
 full = ["credible"]
 
 [build-dependencies]
-vergen-gix = { version = "9", features = ["build", "cargo", "rustc", "si"] }
-anyhow = "1"

--- a/crates/pcl/cli/build.rs
+++ b/crates/pcl/cli/build.rs
@@ -1,26 +1,72 @@
-use anyhow::Result;
-use vergen_gix::{
-    BuildBuilder,
-    CargoBuilder,
-    Emitter,
-    GixBuilder,
-    RustcBuilder,
-    SysinfoBuilder,
+use std::{
+    process::Command,
+    time::{
+        SystemTime,
+        UNIX_EPOCH,
+    },
 };
 
-pub fn main() -> Result<()> {
-    let build = BuildBuilder::all_build()?;
-    let cargo = CargoBuilder::all_cargo()?;
-    let gix = GixBuilder::all_git()?;
-    let rustc = RustcBuilder::all_rustc()?;
-    let si = SysinfoBuilder::all_sysinfo()?;
+pub fn main() {
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=VERGEN_BUILD_TIMESTAMP");
 
-    Emitter::default()
-        .add_instructions(&build)?
-        .add_instructions(&cargo)?
-        .add_instructions(&gix)?
-        .add_instructions(&rustc)?
-        .add_instructions(&si)?
-        .emit()?;
-    Ok(())
+    println!(
+        "cargo:rustc-env=VERGEN_GIT_SHA={}",
+        std::env::var("VERGEN_GIT_SHA")
+            .ok()
+            .or_else(git_sha)
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!(
+        "cargo:rustc-env=VERGEN_BUILD_TIMESTAMP={}",
+        std::env::var("VERGEN_BUILD_TIMESTAMP")
+            .ok()
+            .unwrap_or_else(build_timestamp)
+    );
+}
+
+fn git_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?;
+    let sha = sha.trim();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_string())
+    }
+}
+
+fn build_timestamp() -> String {
+    if let Some(timestamp) = date_timestamp() {
+        return timestamp;
+    }
+
+    SystemTime::now().duration_since(UNIX_EPOCH).map_or_else(
+        |_| "unknown".to_string(),
+        |duration| duration.as_secs().to_string(),
+    )
+}
+
+fn date_timestamp() -> Option<String> {
+    let output = Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let timestamp = String::from_utf8(output.stdout).ok()?;
+    let timestamp = timestamp.trim();
+    if timestamp.is_empty() {
+        None
+    } else {
+        Some(timestamp.to_string())
+    }
 }

--- a/crates/pcl/cli/tests/fixtures/verify-project/assertions/credible.toml
+++ b/crates/pcl/cli/tests/fixtures/verify-project/assertions/credible.toml
@@ -1,0 +1,9 @@
+environment = "production"
+
+[contracts.mock]
+address = "0x0101010101010101010101010101010101010101"
+name = "Mock"
+
+[[contracts.mock.assertions]]
+file = "assertions/src/NoArgsAssertion.a.sol:NoArgsAssertion"
+

--- a/crates/pcl/cli/tests/fixtures/verify-project/assertions/credible.toml
+++ b/crates/pcl/cli/tests/fixtures/verify-project/assertions/credible.toml
@@ -1,4 +1,5 @@
 environment = "production"
+project_id = "550e8400-e29b-41d4-a716-446655440000"
 
 [contracts.mock]
 address = "0x0101010101010101010101010101010101010101"
@@ -6,4 +7,3 @@ name = "Mock"
 
 [[contracts.mock.assertions]]
 file = "assertions/src/NoArgsAssertion.a.sol:NoArgsAssertion"
-

--- a/crates/pcl/cli/tests/fixtures/verify-project/assertions/src/NoArgsAssertion.a.sol
+++ b/crates/pcl/cli/tests/fixtures/verify-project/assertions/src/NoArgsAssertion.a.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface TriggerRecorder {
+    function registerCallTrigger(bytes4 fnSelector) external view;
+}
+
+abstract contract Assertion {
+    TriggerRecorder constant triggerRecorder =
+        TriggerRecorder(address(uint160(uint256(keccak256("TriggerRecorder")))));
+
+    function triggers() external view virtual;
+
+    function registerCallTrigger(bytes4 fnSelector) internal view {
+        triggerRecorder.registerCallTrigger(fnSelector);
+    }
+}
+
+contract NoArgsAssertion is Assertion {
+    function triggers() external view override {
+        registerCallTrigger(this.assertionCheckBool.selector);
+    }
+
+    function assertionCheckBool() external pure returns (bool) {
+        return true;
+    }
+}
+

--- a/crates/pcl/cli/tests/fixtures/verify-project/assertions/test/NoArgsAssertion.t.sol
+++ b/crates/pcl/cli/tests/fixtures/verify-project/assertions/test/NoArgsAssertion.t.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "../src/NoArgsAssertion.a.sol";
+
+contract NoArgsAssertionTest {
+    function testAssertionCheckBool() public {
+        NoArgsAssertion assertion = new NoArgsAssertion();
+        require(assertion.assertionCheckBool(), "expected assertion to pass");
+    }
+}

--- a/crates/pcl/cli/tests/fixtures/verify-project/foundry.toml
+++ b/crates/pcl/cli/tests/fixtures/verify-project/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 src = "assertions/src"
+test = "assertions/test"
 out = "out"
 libs = ["lib"]
 optimizer = true
 optimizer_runs = 200
-

--- a/crates/pcl/cli/tests/fixtures/verify-project/foundry.toml
+++ b/crates/pcl/cli/tests/fixtures/verify-project/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "assertions/src"
+out = "out"
+libs = ["lib"]
+optimizer = true
+optimizer_runs = 200
+

--- a/crates/pcl/cli/tests/verify_cli.rs
+++ b/crates/pcl/cli/tests/verify_cli.rs
@@ -1,0 +1,89 @@
+#[cfg(feature = "full")]
+use std::{
+    fs,
+    path::Path,
+    process::Command,
+};
+
+#[cfg(feature = "full")]
+fn copy_dir(from: &Path, to: &Path) {
+    fs::create_dir_all(to).expect("create fixture destination");
+    for entry in fs::read_dir(from).expect("read fixture directory") {
+        let entry = entry.expect("read fixture entry");
+        let source = entry.path();
+        let destination = to.join(entry.file_name());
+        if source.is_dir() {
+            copy_dir(&source, &destination);
+        } else {
+            fs::copy(&source, &destination).expect("copy fixture file");
+        }
+    }
+}
+
+#[cfg(feature = "full")]
+fn fixture_project() -> tempfile::TempDir {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/verify-project");
+    let temp_dir = tempfile::tempdir().expect("create temp project");
+    copy_dir(&fixture, temp_dir.path());
+    temp_dir
+}
+
+#[cfg(feature = "full")]
+fn assert_verify_success(output: std::process::Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let summary: serde_json::Value = serde_json::from_str(&stdout).expect("json summary");
+    assert_eq!(summary["status"], "success");
+    assert_eq!(summary["total"], 1);
+    assert_eq!(summary["passed"], 1);
+    assert_eq!(summary["failed"], 0);
+    assert_eq!(summary["assertions"][0]["name"], "NoArgsAssertion");
+    assert_eq!(summary["assertions"][0]["status"], "success");
+    assert_eq!(
+        summary["assertions"][0]["triggers"]["0x0f04ec21"],
+        "allCall"
+    );
+}
+
+#[cfg(feature = "full")]
+#[test]
+fn verify_cli_succeeds_for_explicit_fixture_assertion() {
+    let project = fixture_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "verify",
+            "--root",
+            project.path().to_str().expect("utf-8 temp path"),
+            "assertions/src/NoArgsAssertion.a.sol:NoArgsAssertion",
+            "--json",
+        ])
+        .output()
+        .expect("run pcl verify");
+
+    assert_verify_success(output);
+}
+
+#[cfg(feature = "full")]
+#[test]
+fn verify_cli_succeeds_for_credible_toml_fixture() {
+    let project = fixture_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "verify",
+            "--root",
+            project.path().to_str().expect("utf-8 temp path"),
+            "--json",
+        ])
+        .output()
+        .expect("run pcl verify");
+
+    assert_verify_success(output);
+}

--- a/crates/pcl/cli/tests/verify_cli.rs
+++ b/crates/pcl/cli/tests/verify_cli.rs
@@ -52,6 +52,90 @@ fn assert_verify_success(output: std::process::Output) {
 }
 
 #[cfg(feature = "full")]
+fn assert_command_success(output: &std::process::Output, command: &str) {
+    assert!(
+        output.status.success(),
+        "{command} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(feature = "full")]
+#[test]
+fn build_cli_succeeds_for_fixture_project() {
+    let project = fixture_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "build",
+            "--root",
+            project.path().to_str().expect("utf-8 temp path"),
+        ])
+        .output()
+        .expect("run pcl build");
+
+    assert_command_success(&output, "pcl build");
+}
+
+#[cfg(feature = "full")]
+#[test]
+fn test_cli_succeeds_for_fixture_project() {
+    let project = fixture_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "test",
+            "--root",
+            project.path().to_str().expect("utf-8 temp path"),
+        ])
+        .output()
+        .expect("run pcl test");
+
+    assert_command_success(&output, "pcl test");
+}
+
+#[cfg(feature = "full")]
+#[test]
+fn apply_dry_run_builds_and_verifies_fixture_payload_without_api() {
+    let project = fixture_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "--json",
+            "apply",
+            "--root",
+            project.path().to_str().expect("utf-8 temp path"),
+            "--dry-run",
+        ])
+        .output()
+        .expect("run pcl apply dry-run");
+
+    assert_command_success(&output, "pcl apply --dry-run");
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let summary: serde_json::Value = serde_json::from_str(&stdout).expect("json summary");
+    assert_eq!(summary["status"], "dry_run");
+    assert_eq!(
+        summary["project_id"],
+        "550e8400-e29b-41d4-a716-446655440000"
+    );
+    assert_eq!(summary["applied"], false);
+    assert_eq!(summary["preview"], serde_json::Value::Null);
+    assert_eq!(summary["release"], serde_json::Value::Null);
+    assert_eq!(summary["verification"]["status"], "success");
+    assert_eq!(summary["verification"]["passed"], 1);
+    assert_eq!(
+        summary["payload"]["contracts"]["mock"]["assertions"][0]["contractName"],
+        "NoArgsAssertion"
+    );
+    assert!(
+        summary["payload"]["contracts"]["mock"]["assertions"][0]["bytecode"]
+            .as_str()
+            .is_some_and(|bytecode| bytecode.starts_with("0x"))
+    );
+}
+
+#[cfg(feature = "full")]
 #[test]
 fn verify_cli_succeeds_for_explicit_fixture_assertion() {
     let project = fixture_project();

--- a/crates/pcl/cli/tests/workflow_cli.rs
+++ b/crates/pcl/cli/tests/workflow_cli.rs
@@ -1,0 +1,399 @@
+use mockito::Matcher;
+use std::{
+    fs,
+    process::Command,
+};
+
+fn write_valid_auth_config(config_dir: &std::path::Path) {
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"[auth]
+access_token = "test-token"
+refresh_token = "refresh-token"
+expires_at = 4102444800
+email = "agent@example.com"
+"#,
+    )
+    .expect("write test config");
+}
+
+fn run_pcl(config_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .arg("--config-dir")
+        .arg(config_dir)
+        .arg("--json")
+        .args(args)
+        .output()
+        .expect("run pcl")
+}
+
+fn assert_json_success(output: &std::process::Output, command: &str) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "{command} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "{command} wrote stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("json envelope")
+}
+
+fn assert_body_template_fields(
+    config_dir: &std::path::Path,
+    name: &str,
+    args: &[&str],
+    fields: &[&str],
+) {
+    let output = run_pcl(config_dir, args);
+    let envelope = assert_json_success(&output, name);
+    assert_eq!(envelope["status"], "ok", "{name}: {envelope}");
+    assert_eq!(envelope["schema_version"], "pcl.envelope.v1", "{name}");
+    assert!(
+        envelope["next_actions"]
+            .as_array()
+            .is_some_and(|actions| !actions.is_empty()),
+        "{name}: {envelope}"
+    );
+    for field in fields {
+        assert!(
+            envelope["data"].get(field).is_some(),
+            "{name} missing template field {field}: {envelope}"
+        );
+    }
+}
+
+fn mock_incident_export_page(
+    server: &mut mockito::Server,
+    page: &str,
+    status: usize,
+    request_id: &str,
+    body: &str,
+) -> mockito::Mock {
+    server
+        .mock("GET", "/api/v1/views/public/incidents")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("environment".into(), "production".into()),
+            Matcher::UrlEncoded("page".into(), page.into()),
+            Matcher::UrlEncoded("limit".into(), "2".into()),
+        ]))
+        .with_status(status)
+        .with_header("content-type", "application/json")
+        .with_header("x-request-id", request_id)
+        .with_body(body)
+        .expect(1)
+        .create()
+}
+
+#[test]
+fn workflow_body_templates_cover_project_release_families() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config(temp_dir.path());
+    let api = "http://127.0.0.1:9";
+    assert_body_template_fields(
+        temp_dir.path(),
+        "projects",
+        &["projects", "--api-url", api, "--create", "--body-template"],
+        &["project_name", "chain_id"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "contracts",
+        &["contracts", "--api-url", api, "--create", "--body-template"],
+        &["network", "address", "contract_name", "project_id"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "releases",
+        &[
+            "releases",
+            "--api-url",
+            api,
+            "--project",
+            "project-1",
+            "--preview",
+            "--body-template",
+        ],
+        &["environment", "assertionsDir", "contracts"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "deployments",
+        &[
+            "deployments",
+            "--api-url",
+            api,
+            "--project",
+            "project-1",
+            "--confirm",
+            "--body-template",
+        ],
+        &["tx_hash", "chainId", "assertions"],
+    );
+}
+
+#[test]
+fn workflow_body_templates_cover_access_manager_families() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config(temp_dir.path());
+    let api = "http://127.0.0.1:9";
+    assert_body_template_fields(
+        temp_dir.path(),
+        "access",
+        &[
+            "access",
+            "--api-url",
+            api,
+            "--project",
+            "project-1",
+            "--invite",
+            "--body-template",
+        ],
+        &["identifier", "identifier_type", "role"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "integrations",
+        &[
+            "integrations",
+            "--api-url",
+            api,
+            "--project",
+            "project-1",
+            "--provider",
+            "slack",
+            "--configure",
+            "--body-template",
+        ],
+        &["webhook_url", "enabled"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "protocol-manager",
+        &[
+            "protocol-manager",
+            "--api-url",
+            api,
+            "--project",
+            "project-1",
+            "--set",
+            "--body-template",
+        ],
+        &["address", "signature", "nonce"],
+    );
+    assert_body_template_fields(
+        temp_dir.path(),
+        "transfers",
+        &["transfers", "--api-url", api, "--reject", "--body-template"],
+        &["ponder_transfer_id"],
+    );
+}
+
+#[test]
+fn workflow_body_template_defaults_to_toon_envelope() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config(temp_dir.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .arg("--config-dir")
+        .arg(temp_dir.path())
+        .args([
+            "projects",
+            "--api-url",
+            "http://127.0.0.1:9",
+            "--create",
+            "--body-template",
+        ])
+        .output()
+        .expect("run pcl projects body-template");
+
+    assert!(
+        output.status.success(),
+        "body template failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(stdout.starts_with("status: ok\n"), "{stdout}");
+    assert!(
+        stdout.contains("schema_version: pcl.envelope.v1"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("project_name:"), "{stdout}");
+}
+
+#[test]
+fn workflow_mutating_server_error_preserves_request_provenance() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config(temp_dir.path());
+    let mut server = mockito::Server::new();
+    let create = server
+        .mock("POST", "/api/v1/projects")
+        .match_header("authorization", "Bearer test-token")
+        .match_header(
+            "content-type",
+            Matcher::Regex("application/json.*".to_string()),
+        )
+        .match_body(Matcher::Json(serde_json::json!({
+            "project_name": "demo",
+            "chain_id": 1
+        })))
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_header("x-request-id", "req-project-500")
+        .with_body(r#"{"message":"created project but failed after commit"}"#)
+        .expect(1)
+        .create();
+
+    let output = run_pcl(
+        temp_dir.path(),
+        &[
+            "projects",
+            "--api-url",
+            &server.url(),
+            "--create",
+            "--project-name",
+            "demo",
+            "--chain-id",
+            "1",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected server error, got stdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "unexpected stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stderr).expect("json error envelope");
+    assert_eq!(envelope["status"], "error");
+    assert_eq!(envelope["error"]["code"], "api.server_error");
+    assert_eq!(envelope["error"]["http"]["method"], "POST");
+    assert_eq!(envelope["error"]["http"]["path"], "/projects");
+    assert_eq!(envelope["error"]["http"]["status"], 500);
+    assert_eq!(envelope["error"]["http"]["request_id"], "req-project-500");
+    assert_eq!(envelope["error"]["request_id"], "req-project-500");
+    assert_eq!(envelope["request_id"], "req-project-500");
+    assert_eq!(envelope["outcome_ambiguous"], true);
+    assert_eq!(envelope["error"]["mutation"]["side_effecting"], true);
+    assert_eq!(envelope["error"]["mutation"]["outcome_ambiguous"], true);
+    assert!(
+        envelope["suggested_next_actions"]
+            .as_array()
+            .is_some_and(|actions| actions.iter().any(|action| action == "reconcile_mutation")),
+        "{envelope}"
+    );
+    assert!(
+        envelope["next_actions"].as_array().is_some_and(|actions| {
+            actions.iter().any(|action| {
+                action
+                    .as_str()
+                    .is_some_and(|value| value.contains("Do not retry immediately"))
+            })
+        }),
+        "{envelope}"
+    );
+    create.assert();
+}
+
+#[test]
+fn export_incidents_cli_writes_checkpoint_errors_and_resume_command() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    let mut server = mockito::Server::new();
+    let page_1 = mock_incident_export_page(
+        &mut server,
+        "1",
+        200,
+        "req-export-1",
+        r#"{"incidents":[{"id":"i1"},{"id":"i2"}]}"#,
+    );
+    let page_2 = mock_incident_export_page(
+        &mut server,
+        "2",
+        500,
+        "req-export-500",
+        r#"{"message":"temporary page failure"}"#,
+    );
+    let page_3 = mock_incident_export_page(
+        &mut server,
+        "3",
+        200,
+        "req-export-3",
+        r#"{"incidents":[{"id":"i3"}]}"#,
+    );
+
+    let out = temp_dir.path().join("incidents.jsonl");
+    let errors = temp_dir.path().join("errors.jsonl");
+    let checkpoint = temp_dir.path().join("checkpoint.json");
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .arg("--config-dir")
+        .arg(temp_dir.path())
+        .arg("--json")
+        .args([
+            "export",
+            "incidents",
+            "--api-url",
+            &server.url(),
+            "--allow-unauthenticated",
+            "--environment",
+            "production",
+            "--limit",
+            "2",
+            "--max-pages",
+            "3",
+            "--max-retries",
+            "0",
+            "--continue-on-error",
+            "--out",
+        ])
+        .arg(&out)
+        .arg("--errors")
+        .arg(&errors)
+        .arg("--checkpoint")
+        .arg(&checkpoint)
+        .output()
+        .expect("run pcl export incidents");
+
+    let envelope = assert_json_success(&output, "pcl export incidents");
+    assert_eq!(envelope["data"]["pages_fetched"], 2);
+    assert_eq!(envelope["data"]["incidents_written"], 3);
+    assert_eq!(envelope["data"]["errors_written"], 1);
+    assert!(
+        envelope["data"]["resume_command"]
+            .as_str()
+            .is_some_and(|command| {
+                command.contains("pcl export incidents")
+                    && command.contains("--resume")
+                    && command.contains("--continue-on-error")
+            }),
+        "{envelope}"
+    );
+
+    let out_lines = fs::read_to_string(&out).expect("read export output");
+    assert!(out_lines.contains(r#""id":"i1""#), "{out_lines}");
+    assert!(out_lines.contains(r#""id":"i2""#), "{out_lines}");
+    assert!(out_lines.contains(r#""id":"i3""#), "{out_lines}");
+
+    let error_lines = fs::read_to_string(&errors).expect("read export errors");
+    assert!(error_lines.contains(r#""page":2"#), "{error_lines}");
+    assert!(error_lines.contains(r#""status":500"#), "{error_lines}");
+    assert!(error_lines.contains("req-export-500"), "{error_lines}");
+
+    let checkpoint: serde_json::Value =
+        serde_json::from_slice(&fs::read(&checkpoint).expect("read checkpoint"))
+            .expect("checkpoint json");
+    assert_eq!(checkpoint["next_page"], 4);
+    assert_eq!(checkpoint["items_written"], 3);
+
+    page_1.assert();
+    page_2.assert();
+    page_3.assert();
+}

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -85,6 +85,12 @@ pub struct ApplyArgs {
     pub yes: bool,
 
     #[arg(
+        long,
+        help = "Build and verify the release payload without calling the API"
+    )]
+    pub dry_run: bool,
+
+    #[arg(
         short = 'u',
         long = "api-url",
         env = "PCL_API_URL",
@@ -101,6 +107,7 @@ struct ApplyJsonOutput {
     project_id: Uuid,
     #[cfg(feature = "credible")]
     verification: VerificationSummary,
+    payload: Option<PostProjectsProjectIdReleasesBody>,
     preview: Option<PreviewResponse>,
     applied: bool,
     release: Option<PostProjectsProjectIdReleasesResponse>,
@@ -125,6 +132,14 @@ impl ApplyArgs {
         #[cfg(feature = "credible")]
         let verification = Self::verify_all_assertions(&_verification_inputs, json_output)?;
 
+        if self.dry_run {
+            #[cfg(feature = "credible")]
+            Self::print_dry_run_output(json_output, project_id, payload, verification)?;
+            #[cfg(not(feature = "credible"))]
+            Self::print_dry_run_output(json_output, project_id, payload)?;
+            return Ok(());
+        }
+
         let (http_client, base_url) = Self::build_http_client(config, &self.api_url)?;
         let preview = Self::call_preview(&http_client, &base_url, &project_id, &payload).await?;
 
@@ -137,6 +152,7 @@ impl ApplyArgs {
                         project_id,
                         #[cfg(feature = "credible")]
                         verification,
+                        payload: None,
                         preview: Some(preview),
                         applied: false,
                         release: None,
@@ -183,6 +199,7 @@ impl ApplyArgs {
                     project_id,
                     #[cfg(feature = "credible")]
                     verification,
+                    payload: None,
                     preview: Some(preview),
                     applied: true,
                     release: Some(release),
@@ -227,6 +244,58 @@ impl ApplyArgs {
             .map_err(|e| ApplyError::InvalidConfig(format!("Failed to build HTTP client: {e}")))?;
 
         Ok((http_client, base_url))
+    }
+
+    #[cfg(feature = "credible")]
+    fn print_dry_run_output(
+        json_output: bool,
+        project_id: Uuid,
+        payload: PostProjectsProjectIdReleasesBody,
+        verification: VerificationSummary,
+    ) -> Result<(), ApplyError> {
+        if json_output {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&ApplyJsonOutput {
+                    status: "dry_run",
+                    project_id,
+                    verification,
+                    payload: Some(payload),
+                    preview: None,
+                    applied: false,
+                    release: None,
+                })?
+            );
+        } else {
+            println!(
+                "Dry run complete. Built and verified release payload for project {project_id}."
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "credible"))]
+    fn print_dry_run_output(
+        json_output: bool,
+        project_id: Uuid,
+        payload: PostProjectsProjectIdReleasesBody,
+    ) -> Result<(), ApplyError> {
+        if json_output {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&ApplyJsonOutput {
+                    status: "dry_run",
+                    project_id,
+                    payload: Some(payload),
+                    preview: None,
+                    applied: false,
+                    release: None,
+                })?
+            );
+        } else {
+            println!("Dry run complete. Built release payload for project {project_id}.");
+        }
+        Ok(())
     }
 
     async fn call_preview(

--- a/crates/pcl/core/src/verify.rs
+++ b/crates/pcl/core/src/verify.rs
@@ -23,7 +23,10 @@ use assertion_verification::{
 };
 use clap::ValueHint;
 use pcl_common::args::CliArgs;
-use pcl_phoundry::build_and_flatten::BuildAndFlattenArgs;
+use pcl_phoundry::{
+    DEFAULT_ASSERTION_CONTRACTS_DIR,
+    build_and_flatten::BuildAndFlattenArgs,
+};
 use serde::Serialize;
 use std::path::{
     Path,
@@ -135,6 +138,7 @@ impl VerifyArgs {
         let output = BuildAndFlattenArgs {
             root: Some(root.to_path_buf()),
             assertion_contract: contract_name.clone(),
+            contracts: assertion_contracts_dir(assertion),
         }
         .run()
         .map_err(VerifyError::BuildFailed)?;
@@ -159,6 +163,7 @@ impl VerifyArgs {
                 let output = BuildAndFlattenArgs {
                     root: Some(root.to_path_buf()),
                     assertion_contract: contract_name.clone(),
+                    contracts: assertion_contracts_dir(&assertion.file),
                 }
                 .run()
                 .map_err(VerifyError::BuildFailed)?;
@@ -194,6 +199,17 @@ fn parse_assertion_name(arg: &str) -> String {
     } else {
         arg.to_string()
     }
+}
+
+fn assertion_contracts_dir(file: &str) -> PathBuf {
+    let source_path = file.split_once(':').map_or(file, |(path, _)| path);
+    Path::new(source_path)
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map_or_else(
+            || PathBuf::from(DEFAULT_ASSERTION_CONTRACTS_DIR),
+            Path::to_path_buf,
+        )
 }
 
 /// Result of verifying a set of assertions.

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,6 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Transitive through Foundry/Alloy; paste is unmaintained but no direct PCL usage." },
     { id = "RUSTSEC-2024-0437", reason = "Transitive through Foundry/trezor protobuf dependency; tracked upstream." },
     { id = "RUSTSEC-2026-0002", reason = "Transitive lru versions through Foundry/Alloy; tracked upstream." },
-    { id = "RUSTSEC-2026-0097", reason = "Transitive rand 0.8 through Foundry/Alloy; tracked upstream." },
-    { id = "RUSTSEC-2026-0104", reason = "Transitive rustls-webpki through reqwest/Alloy; tracked upstream." },
     { id = "RUSTSEC-2018-0017", reason = "Transitive through credible-sdk assertion-executor -> sled optional credible feature; tracked upstream." },
     { id = "RUSTSEC-2023-0018", reason = "Transitive through credible-sdk assertion-executor -> sled optional credible feature; no direct PCL remove_dir_all usage." },
     { id = "RUSTSEC-2025-0141", reason = "Transitive through credible-sdk assertion-executor optional credible feature; bincode 1.x is complete upstream but unmaintained." },


### PR DESCRIPTION
## Summary
- bump the workspace release version to `1.5.0` so merging this PR into `main` will trigger the version-driven release workflow with a fresh tag target
- replace the `vergen-gix` build dependency with a small local build script so the CLI no longer pulls the vulnerable gitoxide/gix tree just to stamp version metadata
- refresh patched transitive dependencies: `openssl` 0.10.79, `rustls-webpki` 0.103.13, `rand` 0.8.6, and `rpassword` 7.5.2
- remove now-obsolete `cargo deny` ignores for fixed `rand` and `rustls-webpki` advisories while preserving the existing optional credible-sdk ignores needed by `make audit`
- fix the release-only `--features full` compile failure from run `25527295594` by passing `contracts` into `BuildAndFlattenArgs` from `pcl verify`
- add `make full-check` plus a PR CI job that runs the same full-feature compile shape used by the release binary build
- add a checked-in assertion fixture that now covers `pcl build`, `pcl test`, explicit `pcl verify`, `credible.toml` verification, and `pcl apply --dry-run` payload construction without touching the API
- add workflow CLI fixture tests for mutation `--body-template` envelopes, ambiguous mutating 500s with request provenance, and resumable incident exports with checkpoint/error artifacts

## Release behavior
This repo releases from `[workspace.package].version` in `Cargo.toml` on `main` pushes that change `Cargo.toml`. Tag `1.4.0` already exists, so this PR now bumps the workspace and lockfile package versions to `1.5.0`. After merge, `.github/workflows/release.yml` should create tag `1.5.0`, build full-feature binaries, publish the GitHub release assets, and update Homebrew.

## Release failure root cause
The previous `Tag, Release and Publish` run created tag `1.4.0`, then every binary build failed during `Cargo Build Release` because release builds use `cargo-features: full`. That feature set compiles the credible verification path, where `crates/pcl/core/src/verify.rs` still initialized `BuildAndFlattenArgs` without its required `contracts` field.

## CLI safety coverage added
- `pcl build --root <fixture>` catches Foundry/project-layout regressions.
- `pcl test --root <fixture>` catches broken assertion test execution.
- `pcl verify --root <fixture> ... --json` covers both explicit assertion refs and `credible.toml` discovery.
- `pcl apply --root <fixture> --dry-run --json` verifies `credible.toml -> built assertions -> release payload` without requiring live dApp/API state.
- Workflow body-template tests cover `projects`, `contracts`, `releases`, `deployments`, `access`, `integrations`, `protocol-manager`, and `transfers`.
- The mocked mutating 500 test preserves `request_id`, method/path/status, `outcome_ambiguous`, and reconciliation next actions so the CLI does not encourage blind retries after a possible server-side commit.
- The export fixture validates JSONL output, checkpoint state, error JSONL, and `resume_command` after a paginated failure with `--continue-on-error`.

## Validation
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo metadata --locked --no-deps --format-version 1`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo run --locked -q -p pcl -- --version` -> `pcl 1.5.0`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -q -p pcl --features full --test verify_cli`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -q -p pcl --features full --test workflow_cli`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true make ci`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true make audit`

## Remaining alerts after this branch
The remaining lockfile alerts are upstream-pinned through Foundry/Alloy/credible-sdk dependency paths and need upstream dependency movement or feature pruning: `jsonwebtoken`, `protobuf`, `lru`, `tracing-subscriber` 0.2, and `remove_dir_all`.
