### PR TITLE
ci: remove legacy ssh private key secret for pulling private repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
       deny-checks: "advisories"
       deny-preinstalled: true
     secrets:
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -84,17 +83,8 @@ jobs:
       GIT_CONFIG_GLOBAL: /tmp/pcl-release-feature-${{ github.run_id }}-${{ github.run_attempt }}.gitconfig
       RUSTC_WRAPPER: ""
       SCCACHE_DISABLE: "1"
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
-      - name: Configure SSH for private dependencies
-        if: env.SSH_PRIVATE_KEY != ''
-        uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: ${{ env.SSH_PRIVATE_KEY }}
-      - name: Prefer SSH for GitHub dependencies
-        if: env.SSH_PRIVATE_KEY != ''
-        run: git config --file "$GIT_CONFIG_GLOBAL" url."git@github.com:".insteadOf "https://github.com/"
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUST_NIGHTLY_VERSION" --profile minimal --no-self-update
       - name: Check release build surface

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,6 @@ jobs:
       enable-sccache: true
       requires-private-deps: true
     secrets:
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
@@ -185,7 +184,6 @@ jobs:
       draft: false
       prerelease: false
     secrets:
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 


### PR DESCRIPTION
# Description

- removes `SSH_PRIVATE_KEY` for authenticating to Github (on git checkouts) in favor of our Github App