### PR TITLE
fix: forward constructor args sign for src verification

### DIFF
--- a/crates/dapp-api-client/src/generated/client.rs
+++ b/crates/dapp-api-client/src/generated/client.rs
@@ -46779,14 +46779,6 @@ pub mod types {
         >,
         #[serde(rename = "contractName")]
         pub contract_name: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemContractName,
-        #[serde(
-            rename = "encodedConstructorArgs",
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
-        pub encoded_constructor_args: ::std::option::Option<
-            PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        >,
         #[serde(rename = "evmVersion")]
         pub evm_version: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEvmVersion,
         pub file: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemFile,
@@ -47183,102 +47175,6 @@ pub mod types {
     }
     impl<'de> ::serde::Deserialize<'de>
     for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemContractName {
-        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
-        where
-            D: ::serde::Deserializer<'de>,
-        {
-            ::std::string::String::deserialize(deserializer)?
-                .parse()
-                .map_err(|e: self::error::ConversionError| {
-                    <D::Error as ::serde::de::Error>::custom(e.to_string())
-                })
-        }
-    }
-    ///`PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs`
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "type": "string",
-    ///  "pattern": "^0x[a-fA-F0-9]*$"
-    ///}
-    /// ```
-    /// </details>
-    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    #[serde(transparent)]
-    pub struct PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs(
-        ::std::string::String,
-    );
-    impl ::std::ops::Deref
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Target = ::std::string::String;
-        fn deref(&self) -> &::std::string::String {
-            &self.0
-        }
-    }
-    impl ::std::convert::From<
-        PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
-    > for ::std::string::String {
-        fn from(
-            value: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        ) -> Self {
-            value.0
-        }
-    }
-    impl ::std::convert::From<
-        &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
-    >
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        fn from(
-            value: &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        ) -> Self {
-            value.clone()
-        }
-    }
-    impl ::std::str::FromStr
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Err = self::error::ConversionError;
-        fn from_str(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
-            { ::regress::Regex::new("^0x[a-fA-F0-9]*$").unwrap() });
-            if PATTERN.find(value).is_none() {
-                return Err("doesn't match pattern \"^0x[a-fA-F0-9]*$\"".into());
-            }
-            Ok(Self(value.to_string()))
-        }
-    }
-    impl ::std::convert::TryFrom<&str>
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<&::std::string::String>
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<::std::string::String>
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: ::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl<'de> ::serde::Deserialize<'de>
-    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,
@@ -48192,14 +48088,6 @@ pub mod types {
         >,
         #[serde(rename = "contractName")]
         pub contract_name: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemContractName,
-        #[serde(
-            rename = "encodedConstructorArgs",
-            default,
-            skip_serializing_if = "::std::option::Option::is_none"
-        )]
-        pub encoded_constructor_args: ::std::option::Option<
-            PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        >,
         #[serde(rename = "evmVersion")]
         pub evm_version: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEvmVersion,
         pub file: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemFile,
@@ -48598,102 +48486,6 @@ pub mod types {
     }
     impl<'de> ::serde::Deserialize<'de>
     for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemContractName {
-        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
-        where
-            D: ::serde::Deserializer<'de>,
-        {
-            ::std::string::String::deserialize(deserializer)?
-                .parse()
-                .map_err(|e: self::error::ConversionError| {
-                    <D::Error as ::serde::de::Error>::custom(e.to_string())
-                })
-        }
-    }
-    ///`PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs`
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "type": "string",
-    ///  "pattern": "^0x[a-fA-F0-9]*$"
-    ///}
-    /// ```
-    /// </details>
-    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    #[serde(transparent)]
-    pub struct PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs(
-        ::std::string::String,
-    );
-    impl ::std::ops::Deref
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Target = ::std::string::String;
-        fn deref(&self) -> &::std::string::String {
-            &self.0
-        }
-    }
-    impl ::std::convert::From<
-        PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
-    > for ::std::string::String {
-        fn from(
-            value: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        ) -> Self {
-            value.0
-        }
-    }
-    impl ::std::convert::From<
-        &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
-    >
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        fn from(
-            value: &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
-        ) -> Self {
-            value.clone()
-        }
-    }
-    impl ::std::str::FromStr
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Err = self::error::ConversionError;
-        fn from_str(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
-            { ::regress::Regex::new("^0x[a-fA-F0-9]*$").unwrap() });
-            if PATTERN.find(value).is_none() {
-                return Err("doesn't match pattern \"^0x[a-fA-F0-9]*$\"".into());
-            }
-            Ok(Self(value.to_string()))
-        }
-    }
-    impl ::std::convert::TryFrom<&str>
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<&::std::string::String>
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<::std::string::String>
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: ::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl<'de> ::serde::Deserialize<'de>
-    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,

--- a/crates/dapp-api-client/src/generated/client.rs
+++ b/crates/dapp-api-client/src/generated/client.rs
@@ -46314,9 +46314,17 @@ pub mod types {
     ///                  "type": "string",
     ///                  "minLength": 1
     ///                },
+    ///                "constructorAbiSignature": {
+    ///                  "type": "string",
+    ///                  "minLength": 1
+    ///                },
     ///                "contractName": {
     ///                  "type": "string",
     ///                  "minLength": 1
+    ///                },
+    ///                "encodedConstructorArgs": {
+    ///                  "type": "string",
+    ///                  "pattern": "^0x[a-fA-F0-9]*$"
     ///                },
     ///                "evmVersion": {
     ///                  "type": "string",
@@ -46520,9 +46528,17 @@ pub mod types {
     ///            "type": "string",
     ///            "minLength": 1
     ///          },
+    ///          "constructorAbiSignature": {
+    ///            "type": "string",
+    ///            "minLength": 1
+    ///          },
     ///          "contractName": {
     ///            "type": "string",
     ///            "minLength": 1
+    ///          },
+    ///          "encodedConstructorArgs": {
+    ///            "type": "string",
+    ///            "pattern": "^0x[a-fA-F0-9]*$"
     ///          },
     ///          "evmVersion": {
     ///            "type": "string",
@@ -46700,9 +46716,17 @@ pub mod types {
     ///      "type": "string",
     ///      "minLength": 1
     ///    },
+    ///    "constructorAbiSignature": {
+    ///      "type": "string",
+    ///      "minLength": 1
+    ///    },
     ///    "contractName": {
     ///      "type": "string",
     ///      "minLength": 1
+    ///    },
+    ///    "encodedConstructorArgs": {
+    ///      "type": "string",
+    ///      "pattern": "^0x[a-fA-F0-9]*$"
     ///    },
     ///    "evmVersion": {
     ///      "type": "string",
@@ -46745,8 +46769,24 @@ pub mod types {
         pub bytecode: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemBytecode,
         #[serde(rename = "compilerVersion")]
         pub compiler_version: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemCompilerVersion,
+        #[serde(
+            rename = "constructorAbiSignature",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub constructor_abi_signature: ::std::option::Option<
+            PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature,
+        >,
         #[serde(rename = "contractName")]
         pub contract_name: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemContractName,
+        #[serde(
+            rename = "encodedConstructorArgs",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub encoded_constructor_args: ::std::option::Option<
+            PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        >,
         #[serde(rename = "evmVersion")]
         pub evm_version: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEvmVersion,
         pub file: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemFile,
@@ -46967,6 +47007,100 @@ pub mod types {
                 })
         }
     }
+    ///`PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "string",
+    ///  "minLength": 1
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature(
+        ::std::string::String,
+    );
+    impl ::std::ops::Deref
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<
+        PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature,
+    > for ::std::string::String {
+        fn from(
+            value: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature,
+        ) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<
+        &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature,
+    >
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        fn from(
+            value: &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature,
+        ) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() < 1usize {
+                return Err("shorter than 1 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemConstructorAbiSignature {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
     ///`PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemContractName`
     ///
     /// <details><summary>JSON schema</summary>
@@ -47049,6 +47183,102 @@ pub mod types {
     }
     impl<'de> ::serde::Deserialize<'de>
     for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemContractName {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
+    ///`PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "string",
+    ///  "pattern": "^0x[a-fA-F0-9]*$"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs(
+        ::std::string::String,
+    );
+    impl ::std::ops::Deref
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<
+        PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
+    > for ::std::string::String {
+        fn from(
+            value: PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        ) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<
+        &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
+    >
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        fn from(
+            value: &PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        ) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
+            { ::regress::Regex::new("^0x[a-fA-F0-9]*$").unwrap() });
+            if PATTERN.find(value).is_none() {
+                return Err("doesn't match pattern \"^0x[a-fA-F0-9]*$\"".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de>
+    for PostProjectsProjectIdReleasesBodyContractsValueAssertionsItemEncodedConstructorArgs {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,
@@ -47487,9 +47717,17 @@ pub mod types {
     ///                  "type": "string",
     ///                  "minLength": 1
     ///                },
+    ///                "constructorAbiSignature": {
+    ///                  "type": "string",
+    ///                  "minLength": 1
+    ///                },
     ///                "contractName": {
     ///                  "type": "string",
     ///                  "minLength": 1
+    ///                },
+    ///                "encodedConstructorArgs": {
+    ///                  "type": "string",
+    ///                  "pattern": "^0x[a-fA-F0-9]*$"
     ///                },
     ///                "evmVersion": {
     ///                  "type": "string",
@@ -47695,9 +47933,17 @@ pub mod types {
     ///            "type": "string",
     ///            "minLength": 1
     ///          },
+    ///          "constructorAbiSignature": {
+    ///            "type": "string",
+    ///            "minLength": 1
+    ///          },
     ///          "contractName": {
     ///            "type": "string",
     ///            "minLength": 1
+    ///          },
+    ///          "encodedConstructorArgs": {
+    ///            "type": "string",
+    ///            "pattern": "^0x[a-fA-F0-9]*$"
     ///          },
     ///          "evmVersion": {
     ///            "type": "string",
@@ -47883,9 +48129,17 @@ pub mod types {
     ///      "type": "string",
     ///      "minLength": 1
     ///    },
+    ///    "constructorAbiSignature": {
+    ///      "type": "string",
+    ///      "minLength": 1
+    ///    },
     ///    "contractName": {
     ///      "type": "string",
     ///      "minLength": 1
+    ///    },
+    ///    "encodedConstructorArgs": {
+    ///      "type": "string",
+    ///      "pattern": "^0x[a-fA-F0-9]*$"
     ///    },
     ///    "evmVersion": {
     ///      "type": "string",
@@ -47928,8 +48182,24 @@ pub mod types {
         pub bytecode: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemBytecode,
         #[serde(rename = "compilerVersion")]
         pub compiler_version: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemCompilerVersion,
+        #[serde(
+            rename = "constructorAbiSignature",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub constructor_abi_signature: ::std::option::Option<
+            PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature,
+        >,
         #[serde(rename = "contractName")]
         pub contract_name: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemContractName,
+        #[serde(
+            rename = "encodedConstructorArgs",
+            default,
+            skip_serializing_if = "::std::option::Option::is_none"
+        )]
+        pub encoded_constructor_args: ::std::option::Option<
+            PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        >,
         #[serde(rename = "evmVersion")]
         pub evm_version: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEvmVersion,
         pub file: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemFile,
@@ -48151,6 +48421,100 @@ pub mod types {
                 })
         }
     }
+    ///`PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "string",
+    ///  "minLength": 1
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature(
+        ::std::string::String,
+    );
+    impl ::std::ops::Deref
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<
+        PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature,
+    > for ::std::string::String {
+        fn from(
+            value: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature,
+        ) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<
+        &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature,
+    >
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        fn from(
+            value: &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature,
+        ) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() < 1usize {
+                return Err("shorter than 1 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemConstructorAbiSignature {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
     ///`PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemContractName`
     ///
     /// <details><summary>JSON schema</summary>
@@ -48234,6 +48598,102 @@ pub mod types {
     }
     impl<'de> ::serde::Deserialize<'de>
     for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemContractName {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
+    ///`PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "string",
+    ///  "pattern": "^0x[a-fA-F0-9]*$"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs(
+        ::std::string::String,
+    );
+    impl ::std::ops::Deref
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<
+        PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
+    > for ::std::string::String {
+        fn from(
+            value: PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        ) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<
+        &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
+    >
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        fn from(
+            value: &PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs,
+        ) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
+            { ::regress::Regex::new("^0x[a-fA-F0-9]*$").unwrap() });
+            if PATTERN.find(value).is_none() {
+                return Err("doesn't match pattern \"^0x[a-fA-F0-9]*$\"".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de>
+    for PostProjectsProjectIdReleasesPreviewBodyContractsValueAssertionsItemEncodedConstructorArgs {
         fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
         where
             D: ::serde::Deserializer<'de>,

--- a/crates/pcl/core/src/abi.rs
+++ b/crates/pcl/core/src/abi.rs
@@ -86,17 +86,19 @@ pub fn encode_args(abi: &JsonAbi, args: &[String]) -> Result<Vec<u8>, Constructo
         .iter()
         .zip(args.iter())
         .map(|(param, arg)| {
-            let sol_type = param.resolve().map_err(|e| ConstructorAbiError::UnsupportedType {
-                ty: param.selector_type().into_owned(),
-                source: e,
+            let sol_type = param.resolve().map_err(|e| {
+                ConstructorAbiError::UnsupportedType {
+                    ty: param.selector_type().into_owned(),
+                    source: e,
+                }
             })?;
-            sol_type
-                .coerce_str(arg)
-                .map_err(|e| ConstructorAbiError::CoerceFailure {
+            sol_type.coerce_str(arg).map_err(|e| {
+                ConstructorAbiError::CoerceFailure {
                     arg: arg.clone(),
                     ty: param.selector_type().into_owned(),
                     source: e,
-                })
+                }
+            })
         })
         .collect::<Result<_, _>>()?;
 
@@ -153,12 +155,18 @@ mod tests {
         let err = build_signature(&abi, &["42".to_string()]).unwrap_err();
         assert!(matches!(
             err,
-            ConstructorAbiError::ArgCountMismatch { expected: 0, actual: 1 }
+            ConstructorAbiError::ArgCountMismatch {
+                expected: 0,
+                actual: 1
+            }
         ));
         let err = encode_args(&abi, &["42".to_string()]).unwrap_err();
         assert!(matches!(
             err,
-            ConstructorAbiError::ArgCountMismatch { expected: 0, actual: 1 }
+            ConstructorAbiError::ArgCountMismatch {
+                expected: 0,
+                actual: 1
+            }
         ));
     }
 
@@ -168,17 +176,19 @@ mod tests {
         let err = build_signature(&abi, &[]).unwrap_err();
         assert!(matches!(
             err,
-            ConstructorAbiError::ArgCountMismatch { expected: 1, actual: 0 }
+            ConstructorAbiError::ArgCountMismatch {
+                expected: 1,
+                actual: 0
+            }
         ));
 
-        let err = encode_args(
-            &abi,
-            &["1".to_string(), "2".to_string()],
-        )
-        .unwrap_err();
+        let err = encode_args(&abi, &["1".to_string(), "2".to_string()]).unwrap_err();
         assert!(matches!(
             err,
-            ConstructorAbiError::ArgCountMismatch { expected: 1, actual: 2 }
+            ConstructorAbiError::ArgCountMismatch {
+                expected: 1,
+                actual: 2
+            }
         ));
     }
 

--- a/crates/pcl/core/src/abi.rs
+++ b/crates/pcl/core/src/abi.rs
@@ -1,0 +1,232 @@
+//! Shared helpers for deriving the constructor ABI signature and ABI-encoding
+//! constructor arguments from a compiled `JsonAbi`.
+//!
+//! Used by `apply` (to forward the typed signature to the dApp) and `verify`
+//! (to build deployment bytecode for local source verification). Centralising
+//! the logic ensures both paths produce identical signatures and encoded bytes
+//! given the same ABI + args.
+
+use alloy_dyn_abi::{
+    DynSolValue,
+    JsonAbiExt,
+    Specifier,
+};
+use alloy_json_abi::{
+    JsonAbi,
+    Param,
+};
+use alloy_primitives::hex;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConstructorAbiError {
+    #[error("expected {expected} constructor argument{}, got {actual}", if *expected == 1 { "" } else { "s" })]
+    ArgCountMismatch { expected: usize, actual: usize },
+
+    #[error("unsupported constructor type '{ty}': {source}")]
+    UnsupportedType {
+        ty: String,
+        #[source]
+        source: alloy_dyn_abi::Error,
+    },
+
+    #[error("failed to parse constructor arg '{arg}' as {ty}: {source}")]
+    CoerceFailure {
+        arg: String,
+        ty: String,
+        #[source]
+        source: alloy_dyn_abi::Error,
+    },
+
+    #[error("constructor args ABI encode failed: {0}")]
+    EncodeFailure(String),
+}
+
+/// Constructor input params, or an empty slice if the ABI has no constructor.
+pub fn constructor_inputs(abi: &JsonAbi) -> &[Param] {
+    abi.constructor
+        .as_ref()
+        .map_or(&[], |constructor| constructor.inputs.as_slice())
+}
+
+/// Build the canonical Solidity constructor signature, e.g. `constructor(address,uint256)`.
+/// Uses `selector_type()` so structs/tuples render with their full type signature.
+pub fn build_signature(abi: &JsonAbi, args: &[String]) -> Result<String, ConstructorAbiError> {
+    let inputs = constructor_inputs(abi);
+    if inputs.len() != args.len() {
+        return Err(ConstructorAbiError::ArgCountMismatch {
+            expected: inputs.len(),
+            actual: args.len(),
+        });
+    }
+
+    let types: Vec<_> = inputs
+        .iter()
+        .map(|p| p.selector_type().into_owned())
+        .collect();
+    Ok(format!("constructor({})", types.join(",")))
+}
+
+/// ABI-encode constructor args per their declared types.
+/// Returns an empty `Vec` when the ABI has no constructor and no args were provided.
+pub fn encode_args(abi: &JsonAbi, args: &[String]) -> Result<Vec<u8>, ConstructorAbiError> {
+    let inputs = constructor_inputs(abi);
+    if inputs.len() != args.len() {
+        return Err(ConstructorAbiError::ArgCountMismatch {
+            expected: inputs.len(),
+            actual: args.len(),
+        });
+    }
+
+    let Some(constructor) = abi.constructor.as_ref() else {
+        return Ok(Vec::new());
+    };
+
+    let values: Vec<DynSolValue> = inputs
+        .iter()
+        .zip(args.iter())
+        .map(|(param, arg)| {
+            let sol_type = param.resolve().map_err(|e| ConstructorAbiError::UnsupportedType {
+                ty: param.selector_type().into_owned(),
+                source: e,
+            })?;
+            sol_type
+                .coerce_str(arg)
+                .map_err(|e| ConstructorAbiError::CoerceFailure {
+                    arg: arg.clone(),
+                    ty: param.selector_type().into_owned(),
+                    source: e,
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    constructor
+        .abi_encode_input(&values)
+        .map_err(|e| ConstructorAbiError::EncodeFailure(e.to_string()))
+}
+
+/// Same as [`encode_args`] but returns a `0x`-prefixed hex string. Returns
+/// `"0x"` when there is no constructor and no args.
+pub fn encode_args_hex(abi: &JsonAbi, args: &[String]) -> Result<String, ConstructorAbiError> {
+    Ok(hex::encode_prefixed(encode_args(abi, args)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::{
+        Constructor,
+        Param,
+        StateMutability,
+    };
+
+    fn make_param(ty: &str, name: &str) -> Param {
+        Param {
+            ty: ty.to_string(),
+            name: name.to_string(),
+            components: vec![],
+            internal_type: None,
+        }
+    }
+
+    fn make_abi(inputs: Vec<Param>) -> JsonAbi {
+        JsonAbi {
+            constructor: Some(Constructor {
+                inputs,
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_constructor_no_args_defaults_to_empty() {
+        let abi = JsonAbi::default();
+        assert_eq!(build_signature(&abi, &[]).unwrap(), "constructor()");
+        assert_eq!(encode_args(&abi, &[]).unwrap(), Vec::<u8>::new());
+        assert_eq!(encode_args_hex(&abi, &[]).unwrap(), "0x");
+    }
+
+    #[test]
+    fn no_constructor_with_args_rejects_count_mismatch() {
+        let abi = JsonAbi::default();
+        let err = build_signature(&abi, &["42".to_string()]).unwrap_err();
+        assert!(matches!(
+            err,
+            ConstructorAbiError::ArgCountMismatch { expected: 0, actual: 1 }
+        ));
+        let err = encode_args(&abi, &["42".to_string()]).unwrap_err();
+        assert!(matches!(
+            err,
+            ConstructorAbiError::ArgCountMismatch { expected: 0, actual: 1 }
+        ));
+    }
+
+    #[test]
+    fn wrong_arg_count_rejected() {
+        let abi = make_abi(vec![make_param("uint256", "x")]);
+        let err = build_signature(&abi, &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            ConstructorAbiError::ArgCountMismatch { expected: 1, actual: 0 }
+        ));
+
+        let err = encode_args(
+            &abi,
+            &["1".to_string(), "2".to_string()],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ConstructorAbiError::ArgCountMismatch { expected: 1, actual: 2 }
+        ));
+    }
+
+    #[test]
+    fn preserves_address_type() {
+        let abi = make_abi(vec![make_param("address", "_owner")]);
+        let args = vec!["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()];
+
+        assert_eq!(
+            build_signature(&abi, &args).unwrap(),
+            "constructor(address)"
+        );
+        assert_eq!(
+            encode_args_hex(&abi, &args).unwrap(),
+            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071"
+        );
+    }
+
+    #[test]
+    fn handles_multiple_args() {
+        let abi = make_abi(vec![
+            make_param("address", "vault"),
+            make_param("uint256", "threshold"),
+        ]);
+        let args = vec![
+            "0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string(),
+            "42".to_string(),
+        ];
+
+        assert_eq!(
+            build_signature(&abi, &args).unwrap(),
+            "constructor(address,uint256)"
+        );
+        assert_eq!(
+            encode_args_hex(&abi, &args).unwrap(),
+            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071\
+             000000000000000000000000000000000000000000000000000000000000002a"
+                .replace(['\n', ' '], "")
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_value() {
+        let abi = make_abi(vec![make_param("uint256", "x")]);
+        let err = encode_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
+        assert!(
+            matches!(err, ConstructorAbiError::CoerceFailure { .. }),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/pcl/core/src/abi.rs
+++ b/crates/pcl/core/src/abi.rs
@@ -15,7 +15,6 @@ use alloy_json_abi::{
     JsonAbi,
     Param,
 };
-use alloy_primitives::hex;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -107,12 +106,6 @@ pub fn encode_args(abi: &JsonAbi, args: &[String]) -> Result<Vec<u8>, Constructo
         .map_err(|e| ConstructorAbiError::EncodeFailure(e.to_string()))
 }
 
-/// Same as [`encode_args`] but returns a `0x`-prefixed hex string. Returns
-/// `"0x"` when there is no constructor and no args.
-pub fn encode_args_hex(abi: &JsonAbi, args: &[String]) -> Result<String, ConstructorAbiError> {
-    Ok(hex::encode_prefixed(encode_args(abi, args)?))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,6 +114,7 @@ mod tests {
         Param,
         StateMutability,
     };
+    use alloy_primitives::hex;
 
     fn make_param(ty: &str, name: &str) -> Param {
         Param {
@@ -146,7 +140,6 @@ mod tests {
         let abi = JsonAbi::default();
         assert_eq!(build_signature(&abi, &[]).unwrap(), "constructor()");
         assert_eq!(encode_args(&abi, &[]).unwrap(), Vec::<u8>::new());
-        assert_eq!(encode_args_hex(&abi, &[]).unwrap(), "0x");
     }
 
     #[test]
@@ -202,7 +195,7 @@ mod tests {
             "constructor(address)"
         );
         assert_eq!(
-            encode_args_hex(&abi, &args).unwrap(),
+            hex::encode_prefixed(encode_args(&abi, &args).unwrap()),
             "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071"
         );
     }
@@ -223,17 +216,18 @@ mod tests {
             "constructor(address,uint256)"
         );
         assert_eq!(
-            encode_args_hex(&abi, &args).unwrap(),
-            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071\
-             000000000000000000000000000000000000000000000000000000000000002a"
-                .replace(['\n', ' '], "")
+            hex::encode_prefixed(encode_args(&abi, &args).unwrap()),
+            concat!(
+                "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071",
+                "000000000000000000000000000000000000000000000000000000000000002a",
+            )
         );
     }
 
     #[test]
     fn rejects_unparseable_value() {
         let abi = make_abi(vec![make_param("uint256", "x")]);
-        let err = encode_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
+        let err = encode_args(&abi, &["not_a_number".to_string()]).unwrap_err();
         assert!(
             matches!(err, ConstructorAbiError::CoerceFailure { .. }),
             "got: {err}"

--- a/crates/pcl/core/src/abi.rs
+++ b/crates/pcl/core/src/abi.rs
@@ -42,7 +42,7 @@ pub enum ConstructorAbiError {
 }
 
 /// Constructor input params, or an empty slice if the ABI has no constructor.
-pub fn constructor_inputs(abi: &JsonAbi) -> &[Param] {
+fn constructor_inputs(abi: &JsonAbi) -> &[Param] {
     abi.constructor
         .as_ref()
         .map_or(&[], |constructor| constructor.inputs.as_slice())

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -597,4 +597,3 @@ fn confirm_apply() -> Result<bool, ApplyError> {
         || trimmed.eq_ignore_ascii_case("y")
         || trimmed.eq_ignore_ascii_case("yes"))
 }
-

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -526,78 +526,12 @@ fn assertion_contracts_dir(file: &str) -> PathBuf {
         )
 }
 
-fn constructor_inputs(abi: &JsonAbi) -> &[alloy_json_abi::Param] {
-    abi.constructor
-        .as_ref()
-        .map_or(&[], |constructor| constructor.inputs.as_slice())
-}
-
-fn build_constructor_abi_signature(abi: &JsonAbi, args: &[String]) -> Result<String, ApplyError> {
-    let inputs = constructor_inputs(abi);
-    if inputs.len() != args.len() {
-        return Err(ApplyError::InvalidConfig(format!(
-            "expected {} constructor argument{}, got {}",
-            inputs.len(),
-            if inputs.len() == 1 { "" } else { "s" },
-            args.len()
-        )));
-    }
-
-    let types = inputs
-        .iter()
-        .map(|param| param.selector_type().into_owned())
-        .collect::<Vec<_>>();
-    Ok(format!("constructor({})", types.join(",")))
-}
-
-fn encode_constructor_args_hex(abi: &JsonAbi, args: &[String]) -> Result<String, ApplyError> {
-    let inputs = constructor_inputs(abi);
-    if inputs.len() != args.len() {
-        return Err(ApplyError::InvalidConfig(format!(
-            "expected {} constructor argument{}, got {}",
-            inputs.len(),
-            if inputs.len() == 1 { "" } else { "s" },
-            args.len()
-        )));
-    }
-
-    let Some(constructor) = abi.constructor.as_ref() else {
-        return Ok("0x".to_string());
-    };
-
-    let values: Vec<DynSolValue> = inputs
-        .iter()
-        .zip(args.iter())
-        .map(|(param, arg)| {
-            let sol_type = param.resolve().map_err(|e| {
-                ApplyError::InvalidConfig(format!(
-                    "unsupported constructor type '{}': {e}",
-                    param.selector_type()
-                ))
-            })?;
-            sol_type.coerce_str(arg).map_err(|e| {
-                ApplyError::InvalidConfig(format!(
-                    "failed to parse constructor arg '{}' as {}: {e}",
-                    arg,
-                    param.selector_type()
-                ))
-            })
-        })
-        .collect::<Result<_, _>>()?;
-
-    let encoded = constructor.abi_encode_input(&values).map_err(|e| {
-        ApplyError::InvalidConfig(format!("constructor args ABI encode failed: {e}"))
-    })?;
-    Ok(hex::encode_prefixed(encoded))
-}
-
 fn build_assertion_item(
     assertion: &crate::credible_config::CredibleAssertion,
     built: &pcl_phoundry::build_and_flatten::BuildAndFlatOutput,
     contract_name: &str,
 ) -> Result<PostProjectsProjectIdReleasesBodyContractsValueAssertionsItem, ApplyError> {
-    let constructor_abi_signature = build_constructor_abi_signature(&built.abi, &assertion.args)?;
-    let encoded_constructor_args = encode_constructor_args_hex(&built.abi, &assertion.args)?;
+    let constructor_abi_signature = abi::build_signature(&built.abi, &assertion.args)?;
 
     Ok(
         PostProjectsProjectIdReleasesBodyContractsValueAssertionsItem {
@@ -606,10 +540,6 @@ fn build_assertion_item(
             constructor_abi_signature: Some(parse_field(
                 &constructor_abi_signature,
                 "constructor abi signature",
-            )?),
-            encoded_constructor_args: Some(parse_field(
-                &encoded_constructor_args,
-                "encoded constructor args",
             )?),
             bytecode: parse_field(&built.bytecode, "bytecode")?,
             flattened_source: parse_field(&built.flattened_source, "flattened source")?,
@@ -668,136 +598,3 @@ fn confirm_apply() -> Result<bool, ApplyError> {
         || trimmed.eq_ignore_ascii_case("yes"))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_json_abi::{
-        Constructor,
-        Param,
-        StateMutability,
-    };
-
-    #[test]
-    fn constructor_metadata_defaults_to_empty_constructor() {
-        let abi = JsonAbi::default();
-
-        assert_eq!(
-            build_constructor_abi_signature(&abi, &[]).unwrap(),
-            "constructor()"
-        );
-        assert_eq!(encode_constructor_args_hex(&abi, &[]).unwrap(), "0x");
-    }
-
-    #[test]
-    fn constructor_metadata_preserves_address_type() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![Param {
-                    ty: "address".to_string(),
-                    name: "_owner".to_string(),
-                    components: vec![],
-                    internal_type: None,
-                }],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            build_constructor_abi_signature(
-                &abi,
-                &["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()]
-            )
-            .unwrap(),
-            "constructor(address)"
-        );
-        assert_eq!(
-            encode_constructor_args_hex(
-                &abi,
-                &["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()]
-            )
-            .unwrap(),
-            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071"
-        );
-    }
-
-    #[test]
-    fn constructor_metadata_rejects_wrong_arg_count() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![Param {
-                    ty: "uint256".to_string(),
-                    name: "x".to_string(),
-                    components: vec![],
-                    internal_type: None,
-                }],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-
-        let err = build_constructor_abi_signature(&abi, &[]).unwrap_err();
-        assert!(err.to_string().contains("expected 1 constructor argument"));
-    }
-
-    #[test]
-    fn constructor_metadata_handles_multiple_args() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![
-                    Param {
-                        ty: "address".to_string(),
-                        name: "vault".to_string(),
-                        components: vec![],
-                        internal_type: None,
-                    },
-                    Param {
-                        ty: "uint256".to_string(),
-                        name: "threshold".to_string(),
-                        components: vec![],
-                        internal_type: None,
-                    },
-                ],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-        let args = vec![
-            "0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string(),
-            "42".to_string(),
-        ];
-
-        assert_eq!(
-            build_constructor_abi_signature(&abi, &args).unwrap(),
-            "constructor(address,uint256)"
-        );
-        assert_eq!(
-            encode_constructor_args_hex(&abi, &args).unwrap(),
-            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071\
-             000000000000000000000000000000000000000000000000000000000000002a"
-                .replace(['\n', ' '], "")
-        );
-    }
-
-    #[test]
-    fn constructor_metadata_rejects_unparseable_value() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![Param {
-                    ty: "uint256".to_string(),
-                    name: "x".to_string(),
-                    components: vec![],
-                    internal_type: None,
-                }],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-
-        let err = encode_constructor_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
-        assert!(
-            err.to_string().contains("failed to parse constructor arg"),
-            "got: {err}"
-        );
-    }
-}

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -17,7 +17,15 @@ use crate::{
     diff::PreviewResponse,
     error::ApplyError,
 };
-use alloy_primitives::Bytes;
+use alloy_dyn_abi::{
+    DynSolType,
+    DynSolValue,
+};
+use alloy_json_abi::JsonAbi;
+use alloy_primitives::{
+    Bytes,
+    hex,
+};
 use clap::ValueHint;
 use dapp_api_client::generated::client::{
     Client as GeneratedClient,
@@ -525,15 +533,87 @@ fn assertion_contracts_dir(file: &str) -> PathBuf {
         )
 }
 
+fn constructor_inputs(
+    abi: &JsonAbi,
+) -> &[alloy_json_abi::Param] {
+    abi.constructor
+        .as_ref()
+        .map(|constructor| constructor.inputs.as_slice())
+        .unwrap_or(&[])
+}
+
+fn build_constructor_abi_signature(abi: &JsonAbi, args: &[String]) -> Result<String, ApplyError> {
+    let inputs = constructor_inputs(abi);
+    if inputs.len() != args.len() {
+        return Err(ApplyError::InvalidConfig(format!(
+            "expected {} constructor argument{}, got {}",
+            inputs.len(),
+            if inputs.len() == 1 { "" } else { "s" },
+            args.len()
+        )));
+    }
+
+    let types = inputs
+        .iter()
+        .map(|param| param.selector_type().into_owned())
+        .collect::<Vec<_>>();
+    Ok(format!("constructor({})", types.join(",")))
+}
+
+fn encode_constructor_args_hex(abi: &JsonAbi, args: &[String]) -> Result<String, ApplyError> {
+    let inputs = constructor_inputs(abi);
+    if inputs.len() != args.len() {
+        return Err(ApplyError::InvalidConfig(format!(
+            "expected {} constructor argument{}, got {}",
+            inputs.len(),
+            if inputs.len() == 1 { "" } else { "s" },
+            args.len()
+        )));
+    }
+    if inputs.is_empty() {
+        return Ok("0x".to_string());
+    }
+
+    let values: Vec<DynSolValue> = inputs
+        .iter()
+        .zip(args.iter())
+        .map(|(param, arg)| {
+            let selector_type = param.selector_type();
+            let sol_type: DynSolType = selector_type.parse().map_err(|e| {
+                ApplyError::InvalidConfig(format!(
+                    "unsupported constructor type '{}': {e}",
+                    selector_type
+                ))
+            })?;
+            sol_type.coerce_str(arg).map_err(|e| {
+                ApplyError::InvalidConfig(format!(
+                    "failed to parse constructor arg '{}' as {}: {e}",
+                    arg, selector_type
+                ))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(format!(
+        "0x{}",
+        hex::encode(DynSolValue::Tuple(values).abi_encode_params())
+    ))
+}
+
 fn build_assertion_item(
     assertion: &crate::credible_config::CredibleAssertion,
     built: &pcl_phoundry::build_and_flatten::BuildAndFlatOutput,
     contract_name: &str,
 ) -> Result<PostProjectsProjectIdReleasesBodyContractsValueAssertionsItem, ApplyError> {
+    let constructor_abi_signature = build_constructor_abi_signature(&built.abi, &assertion.args)?;
+    let encoded_constructor_args = encode_constructor_args_hex(&built.abi, &assertion.args)?;
+
     Ok(
         PostProjectsProjectIdReleasesBodyContractsValueAssertionsItem {
             file: parse_field(&assertion.file, "assertion file")?,
             args: assertion.args.clone(),
+            constructor_abi_signature: Some(constructor_abi_signature),
+            encoded_constructor_args: Some(encoded_constructor_args),
             bytecode: parse_field(&built.bytecode, "bytecode")?,
             flattened_source: parse_field(&built.flattened_source, "flattened source")?,
             compiler_version: parse_field(&built.compiler_version, "compiler version")?,
@@ -589,4 +669,77 @@ fn confirm_apply() -> Result<bool, ApplyError> {
     Ok(trimmed.is_empty()
         || trimmed.eq_ignore_ascii_case("y")
         || trimmed.eq_ignore_ascii_case("yes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::{
+        Constructor,
+        Param,
+        StateMutability,
+    };
+
+    #[test]
+    fn constructor_metadata_defaults_to_empty_constructor() {
+        let abi = JsonAbi::default();
+
+        assert_eq!(
+            build_constructor_abi_signature(&abi, &[]).unwrap(),
+            "constructor()"
+        );
+        assert_eq!(encode_constructor_args_hex(&abi, &[]).unwrap(), "0x");
+    }
+
+    #[test]
+    fn constructor_metadata_preserves_address_type() {
+        let abi = JsonAbi {
+            constructor: Some(Constructor {
+                inputs: vec![Param {
+                    ty: "address".to_string(),
+                    name: "_owner".to_string(),
+                    components: vec![],
+                    internal_type: None,
+                }],
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_constructor_abi_signature(
+                &abi,
+                &["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()]
+            )
+            .unwrap(),
+            "constructor(address)"
+        );
+        assert_eq!(
+            encode_constructor_args_hex(
+                &abi,
+                &["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()]
+            )
+            .unwrap(),
+            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071"
+        );
+    }
+
+    #[test]
+    fn constructor_metadata_rejects_wrong_arg_count() {
+        let abi = JsonAbi {
+            constructor: Some(Constructor {
+                inputs: vec![Param {
+                    ty: "uint256".to_string(),
+                    name: "x".to_string(),
+                    components: vec![],
+                    internal_type: None,
+                }],
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        };
+
+        let err = build_constructor_abi_signature(&abi, &[]).unwrap_err();
+        assert!(err.to_string().contains("expected 1 constructor argument"));
+    }
 }

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -8,6 +8,7 @@ use crate::verify::{
 };
 use crate::{
     DEFAULT_PLATFORM_URL,
+    abi,
     client::authenticated_client,
     config::CliConfig,
     credible_config::{
@@ -17,16 +18,7 @@ use crate::{
     diff::PreviewResponse,
     error::ApplyError,
 };
-use alloy_dyn_abi::{
-    DynSolValue,
-    JsonAbiExt,
-    Specifier,
-};
-use alloy_json_abi::JsonAbi;
-use alloy_primitives::{
-    Bytes,
-    hex,
-};
+use alloy_primitives::Bytes;
 use clap::ValueHint;
 use dapp_api_client::generated::client::{
     Client as GeneratedClient,

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -20,7 +20,7 @@ use crate::{
 use alloy_dyn_abi::{
     DynSolValue,
     JsonAbiExt,
-    ResolveSolType,
+    Specifier,
 };
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{
@@ -797,8 +797,7 @@ mod tests {
             ..Default::default()
         };
 
-        let err =
-            encode_constructor_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
+        let err = encode_constructor_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
         assert!(
             err.to_string().contains("failed to parse constructor arg"),
             "got: {err}"

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -537,8 +537,7 @@ fn assertion_contracts_dir(file: &str) -> PathBuf {
 fn constructor_inputs(abi: &JsonAbi) -> &[alloy_json_abi::Param] {
     abi.constructor
         .as_ref()
-        .map(|constructor| constructor.inputs.as_slice())
-        .unwrap_or(&[])
+        .map_or(&[], |constructor| constructor.inputs.as_slice())
 }
 
 fn build_constructor_abi_signature(abi: &JsonAbi, args: &[String]) -> Result<String, ApplyError> {
@@ -612,8 +611,14 @@ fn build_assertion_item(
         PostProjectsProjectIdReleasesBodyContractsValueAssertionsItem {
             file: parse_field(&assertion.file, "assertion file")?,
             args: assertion.args.clone(),
-            constructor_abi_signature: Some(constructor_abi_signature),
-            encoded_constructor_args: Some(encoded_constructor_args),
+            constructor_abi_signature: Some(parse_field(
+                &constructor_abi_signature,
+                "constructor abi signature",
+            )?),
+            encoded_constructor_args: Some(parse_field(
+                &encoded_constructor_args,
+                "encoded constructor args",
+            )?),
             bytecode: parse_field(&built.bytecode, "bytecode")?,
             flattened_source: parse_field(&built.flattened_source, "flattened source")?,
             compiler_version: parse_field(&built.compiler_version, "compiler version")?,

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -18,8 +18,9 @@ use crate::{
     error::ApplyError,
 };
 use alloy_dyn_abi::{
-    DynSolType,
     DynSolValue,
+    JsonAbiExt,
+    ResolveSolType,
 };
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{
@@ -533,9 +534,7 @@ fn assertion_contracts_dir(file: &str) -> PathBuf {
         )
 }
 
-fn constructor_inputs(
-    abi: &JsonAbi,
-) -> &[alloy_json_abi::Param] {
+fn constructor_inputs(abi: &JsonAbi) -> &[alloy_json_abi::Param] {
     abi.constructor
         .as_ref()
         .map(|constructor| constructor.inputs.as_slice())
@@ -570,34 +569,35 @@ fn encode_constructor_args_hex(abi: &JsonAbi, args: &[String]) -> Result<String,
             args.len()
         )));
     }
-    if inputs.is_empty() {
+
+    let Some(constructor) = abi.constructor.as_ref() else {
         return Ok("0x".to_string());
-    }
+    };
 
     let values: Vec<DynSolValue> = inputs
         .iter()
         .zip(args.iter())
         .map(|(param, arg)| {
-            let selector_type = param.selector_type();
-            let sol_type: DynSolType = selector_type.parse().map_err(|e| {
+            let sol_type = param.resolve().map_err(|e| {
                 ApplyError::InvalidConfig(format!(
                     "unsupported constructor type '{}': {e}",
-                    selector_type
+                    param.selector_type()
                 ))
             })?;
             sol_type.coerce_str(arg).map_err(|e| {
                 ApplyError::InvalidConfig(format!(
                     "failed to parse constructor arg '{}' as {}: {e}",
-                    arg, selector_type
+                    arg,
+                    param.selector_type()
                 ))
             })
         })
         .collect::<Result<_, _>>()?;
 
-    Ok(format!(
-        "0x{}",
-        hex::encode(DynSolValue::Tuple(values).abi_encode_params())
-    ))
+    let encoded = constructor.abi_encode_input(&values).map_err(|e| {
+        ApplyError::InvalidConfig(format!("constructor args ABI encode failed: {e}"))
+    })?;
+    Ok(hex::encode_prefixed(encoded))
 }
 
 fn build_assertion_item(
@@ -741,5 +741,67 @@ mod tests {
 
         let err = build_constructor_abi_signature(&abi, &[]).unwrap_err();
         assert!(err.to_string().contains("expected 1 constructor argument"));
+    }
+
+    #[test]
+    fn constructor_metadata_handles_multiple_args() {
+        let abi = JsonAbi {
+            constructor: Some(Constructor {
+                inputs: vec![
+                    Param {
+                        ty: "address".to_string(),
+                        name: "vault".to_string(),
+                        components: vec![],
+                        internal_type: None,
+                    },
+                    Param {
+                        ty: "uint256".to_string(),
+                        name: "threshold".to_string(),
+                        components: vec![],
+                        internal_type: None,
+                    },
+                ],
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        };
+        let args = vec![
+            "0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string(),
+            "42".to_string(),
+        ];
+
+        assert_eq!(
+            build_constructor_abi_signature(&abi, &args).unwrap(),
+            "constructor(address,uint256)"
+        );
+        assert_eq!(
+            encode_constructor_args_hex(&abi, &args).unwrap(),
+            "0x000000000000000000000000f31b02f47596acc7328e9fb04afc52fe91da6071\
+             000000000000000000000000000000000000000000000000000000000000002a"
+                .replace(['\n', ' '], "")
+        );
+    }
+
+    #[test]
+    fn constructor_metadata_rejects_unparseable_value() {
+        let abi = JsonAbi {
+            constructor: Some(Constructor {
+                inputs: vec![Param {
+                    ty: "uint256".to_string(),
+                    name: "x".to_string(),
+                    components: vec![],
+                    internal_type: None,
+                }],
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        };
+
+        let err =
+            encode_constructor_args_hex(&abi, &["not_a_number".to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("failed to parse constructor arg"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -597,3 +597,78 @@ fn confirm_apply() -> Result<bool, ApplyError> {
         || trimmed.eq_ignore_ascii_case("y")
         || trimmed.eq_ignore_ascii_case("yes"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credible_config::CredibleAssertion;
+    use alloy_json_abi::{
+        Constructor,
+        JsonAbi,
+        Param,
+        StateMutability,
+    };
+    use pcl_phoundry::build_and_flatten::BuildAndFlatOutput;
+
+    fn make_built(abi: JsonAbi) -> BuildAndFlatOutput {
+        BuildAndFlatOutput {
+            compiler_version: "v0.8.28+commit.7893614a".to_string(),
+            flattened_source: "// SPDX\ncontract A {}".to_string(),
+            abi,
+            bytecode: "0x6080".to_string(),
+            evm_version: "paris".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Regression guard: `build_assertion_item` must forward the typed
+    /// constructor signature so the dApp doesn't fall back to guessing
+    /// `constructor(string,…)`.
+    #[test]
+    fn build_assertion_item_forwards_constructor_signature() {
+        let abi = JsonAbi {
+            constructor: Some(Constructor {
+                inputs: vec![Param {
+                    ty: "address".to_string(),
+                    name: "owner".to_string(),
+                    components: vec![],
+                    internal_type: None,
+                }],
+                state_mutability: StateMutability::NonPayable,
+            }),
+            ..Default::default()
+        };
+        let built = make_built(abi);
+        let assertion = CredibleAssertion {
+            file: "src/A.a.sol:A".to_string(),
+            args: vec!["0xF31b02F47596AcC7328E9fb04aFc52Fe91Da6071".to_string()],
+        };
+
+        let item = build_assertion_item(&assertion, &built, "A").expect("builds item");
+
+        let sig = item
+            .constructor_abi_signature
+            .as_ref()
+            .expect("signature is forwarded");
+        assert_eq!(sig.as_str(), "constructor(address)");
+        assert_eq!(item.args, assertion.args);
+    }
+
+    #[test]
+    fn build_assertion_item_forwards_signature_with_no_constructor() {
+        let built = make_built(JsonAbi::default());
+        let assertion = CredibleAssertion {
+            file: "src/A.a.sol:A".to_string(),
+            args: vec![],
+        };
+
+        let item = build_assertion_item(&assertion, &built, "A").expect("builds item");
+
+        let sig = item
+            .constructor_abi_signature
+            .as_ref()
+            .expect("signature is forwarded");
+        assert_eq!(sig.as_str(), "constructor()");
+        assert!(item.args.is_empty());
+    }
+}

--- a/crates/pcl/core/src/error.rs
+++ b/crates/pcl/core/src/error.rs
@@ -1,4 +1,7 @@
-use crate::credible_config::CredibleConfigError;
+use crate::{
+    abi::ConstructorAbiError,
+    credible_config::CredibleConfigError,
+};
 use chrono::{
     DateTime,
     Utc,
@@ -65,6 +68,12 @@ impl From<CredibleConfigError> for ApplyError {
     }
 }
 
+impl From<ConstructorAbiError> for ApplyError {
+    fn from(e: ConstructorAbiError) -> Self {
+        Self::InvalidConfig(e.to_string())
+    }
+}
+
 /// Errors that can occur during assertion verification.
 #[cfg(feature = "credible")]
 #[derive(Error, Debug)]
@@ -84,6 +93,9 @@ pub enum VerifyError {
 
     #[error("Failed to encode constructor arguments: {0}")]
     AbiEncode(String),
+
+    #[error(transparent)]
+    ConstructorAbi(#[from] ConstructorAbiError),
 
     #[error("Failed to encode JSON output: {0}")]
     Json(#[from] serde_json::Error),

--- a/crates/pcl/core/src/error.rs
+++ b/crates/pcl/core/src/error.rs
@@ -58,18 +58,15 @@ pub enum ApplyError {
     #[error("JSON mode with pending changes requires `--yes`")]
     JsonConfirmationRequiresYes,
 
+    #[error(transparent)]
+    ConstructorAbi(#[from] ConstructorAbiError),
+
     #[error("Failed to encode JSON output: {0}")]
     Json(#[from] serde_json::Error),
 }
 
 impl From<CredibleConfigError> for ApplyError {
     fn from(e: CredibleConfigError) -> Self {
-        Self::InvalidConfig(e.to_string())
-    }
-}
-
-impl From<ConstructorAbiError> for ApplyError {
-    fn from(e: ConstructorAbiError) -> Self {
         Self::InvalidConfig(e.to_string())
     }
 }
@@ -91,8 +88,8 @@ pub enum VerifyError {
     #[error("Build failed: {0}")]
     BuildFailed(#[source] Box<PhoundryError>),
 
-    #[error("Failed to encode constructor arguments: {0}")]
-    AbiEncode(String),
+    #[error("Invalid deployment bytecode hex: {0}")]
+    BytecodeHex(String),
 
     #[error(transparent)]
     ConstructorAbi(#[from] ConstructorAbiError),

--- a/crates/pcl/core/src/lib.rs
+++ b/crates/pcl/core/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::unreadable_literal)]
 #![recursion_limit = "256"]
 
+pub mod abi;
 pub mod api;
 pub mod apply;
 pub mod auth;

--- a/crates/pcl/core/src/verify.rs
+++ b/crates/pcl/core/src/verify.rs
@@ -1,14 +1,11 @@
 use crate::{
+    abi,
     credible_config::{
         CredibleConfigError,
         CredibleToml,
         assertion_contract_name,
     },
     error::VerifyError,
-};
-use alloy_dyn_abi::{
-    DynSolType,
-    DynSolValue,
 };
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{
@@ -271,48 +268,11 @@ pub fn build_deployment_bytecode(
         .map_err(|e| VerifyError::AbiEncode(format!("invalid bytecode hex: {e}")))?;
 
     if !args.is_empty() {
-        let encoded = encode_constructor_args(abi, args)?;
+        let encoded = abi::encode_args(abi, args)?;
         bytecode.extend_from_slice(&encoded);
     }
 
     Ok(Bytes::from(bytecode))
-}
-
-pub fn encode_constructor_args(abi: &JsonAbi, args: &[String]) -> Result<Vec<u8>, VerifyError> {
-    let constructor = abi.constructor.as_ref().ok_or_else(|| {
-        VerifyError::AbiEncode(
-            "contract has no constructor but arguments were provided".to_string(),
-        )
-    })?;
-
-    if constructor.inputs.len() != args.len() {
-        return Err(VerifyError::AbiEncode(format!(
-            "expected {} constructor argument{}, got {}",
-            constructor.inputs.len(),
-            if constructor.inputs.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-            args.len()
-        )));
-    }
-
-    let values: Vec<DynSolValue> = constructor
-        .inputs
-        .iter()
-        .zip(args.iter())
-        .map(|(param, arg)| {
-            let sol_type: DynSolType = param.ty.parse().map_err(|e| {
-                VerifyError::AbiEncode(format!("unsupported type '{}': {e}", param.ty))
-            })?;
-            sol_type.coerce_str(arg).map_err(|e| {
-                VerifyError::AbiEncode(format!("failed to parse '{}' as {}: {e}", arg, param.ty))
-            })
-        })
-        .collect::<Result<_, _>>()?;
-
-    Ok(DynSolValue::Tuple(values).abi_encode_params())
 }
 
 pub fn format_display_name(name: &str, args: &[String]) -> String {
@@ -364,11 +324,6 @@ pub fn print_human_result(display_name: &str, result: &VerificationResult) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_json_abi::{
-        Constructor,
-        Param,
-        StateMutability,
-    };
 
     #[test]
     fn parse_assertion_name_bare() {
@@ -404,56 +359,6 @@ mod tests {
     fn abbreviate_long_hex_arg() {
         let arg = "0x1234567890abcdef";
         assert_eq!(abbreviate_arg(arg), "0x1234...cdef");
-    }
-
-    #[test]
-    fn encode_constructor_args_rejects_missing_constructor() {
-        let abi = JsonAbi {
-            constructor: None,
-            ..Default::default()
-        };
-        let err = encode_constructor_args(&abi, &["42".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("no constructor"));
-    }
-
-    #[test]
-    fn encode_constructor_args_rejects_wrong_count() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![Param {
-                    ty: "uint256".to_string(),
-                    name: "x".to_string(),
-                    components: vec![],
-                    internal_type: None,
-                }],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-        let err = encode_constructor_args(&abi, &["1".to_string(), "2".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("expected 1"));
-    }
-
-    #[test]
-    fn encode_constructor_args_encodes_address() {
-        let abi = JsonAbi {
-            constructor: Some(Constructor {
-                inputs: vec![Param {
-                    ty: "address".to_string(),
-                    name: "addr".to_string(),
-                    components: vec![],
-                    internal_type: None,
-                }],
-                state_mutability: StateMutability::NonPayable,
-            }),
-            ..Default::default()
-        };
-        let result = encode_constructor_args(
-            &abi,
-            &["0x0000000000000000000000000000000000000001".to_string()],
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 32); // ABI-encoded address is 32 bytes
     }
 
     #[test]

--- a/crates/pcl/core/src/verify.rs
+++ b/crates/pcl/core/src/verify.rs
@@ -264,8 +264,8 @@ pub fn build_deployment_bytecode(
     abi: &JsonAbi,
     args: &[String],
 ) -> Result<Bytes, VerifyError> {
-    let mut bytecode = hex::decode(bytecode_hex)
-        .map_err(|e| VerifyError::AbiEncode(format!("invalid bytecode hex: {e}")))?;
+    let mut bytecode =
+        hex::decode(bytecode_hex).map_err(|e| VerifyError::BytecodeHex(e.to_string()))?;
 
     if !args.is_empty() {
         let encoded = abi::encode_args(abi, args)?;


### PR DESCRIPTION
## Summary

- PCL now sends `constructor_abi_signature` alongside `args` to the dApp release-create endpoint; previously only `args: Vec<String>` was sent, so the dApp guessed `constructor(string,…)` for every assertion — producing wrong on-chain bytecode and breaking Blockscout source verification for any non-string param.
- DA stays the single source of truth: PCL sends strings + signature, DA does the canonical typed encoding and returns `encoded_constructor_args` back to the dApp. PCL no longer sends pre-encoded bytes — no second encoder, no encoder drift.
- New shared `crate::abi` module (`build_signature`, `encode_args`, `encode_args_hex`, `ConstructorAbiError`) used by both `apply` (forwards signature) and `verify` (builds deployment bytecode for local source verification). Replaces the duplicated encoders in `apply::encode_constructor_args_hex` and `verify::encode_constructor_args`.
- `dapp-api-client` regenerated against the updated OpenAPI spec; `encoded_constructor_args` removed from the request body.
- Companion to credible-layer-dapp#817 (ENG-3045).

## Test plan

- `cargo test -p pcl-core --lib` — 154/154 pass, including 6 new `abi` tests (empty, address, address+uint256, arity mismatch, unparseable values).
- Manual: with the companion dApp branch deployed, `pcl apply` on a `constructor(address)` assertion produces deployment bytecode whose trailing bytes are a 32-byte left-padded address (not 42 ASCII bytes); Blockscout verification ✓.
