### PR TITLE
fix: restore main after stale VerifyError::AbiEncode reintroduced by #96

### DIFF
--- a/crates/pcl/cli/src/main.rs
+++ b/crates/pcl/cli/src/main.rs
@@ -373,6 +373,13 @@ fn verify_error_envelope(err: &VerifyError) -> Value {
                 &["pcl build --help", "pcl verify --help"],
             )
         }
+        VerifyError::BytecodeHex(_) => {
+            (
+                "verify.invalid_bytecode_hex",
+                err.to_string(),
+                &["pcl verify --help"],
+            )
+        }
         VerifyError::ConstructorAbi(_) => {
             (
                 "verify.invalid_constructor_args",

--- a/crates/pcl/cli/src/main.rs
+++ b/crates/pcl/cli/src/main.rs
@@ -373,7 +373,7 @@ fn verify_error_envelope(err: &VerifyError) -> Value {
                 &["pcl build --help", "pcl verify --help"],
             )
         }
-        VerifyError::AbiEncode(_) => {
+        VerifyError::ConstructorAbi(_) => {
             (
                 "verify.invalid_constructor_args",
                 err.to_string(),


### PR DESCRIPTION
The squash-merge of #96 reintroduced `VerifyError::AbiEncode(_)` at `crates/pcl/cli/src/main.rs:376`, but the variant was renamed to `ConstructorAbi` before #96 landed (the enum in `crates/pcl/core/src/error.rs` no longer has `AbiEncode`).

`Release Feature Check` on main currently fails with:
```
error[E0599]: no variant or associated item named `AbiEncode` found for enum `VerifyError`
  --> crates/pcl/cli/src/main.rs:376:22
```

Root cause: PR #96 was approved with only the `license/cla` check active on its stale branch — the Rust Test & Lint / Release Feature Check jobs that exist on newer PRs were never re-triggered on it.

This is a one-line rename to unbreak the release build before continuing the #98→#101 stack.

## Test plan
- [ ] `Release Feature Check` passes
- [ ] `Rust Test & Lint` passes