### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable user-facing changes should be recorded here.
 
 ## Unreleased
 
+## 1.5.0 - 2026-05-29
+
+### Breaking changes
+
+- Removed the top-level `pcl transfers` command. Use the per-project workflow commands instead.
+- Removed the hidden legacy `--format json` / `--format toon` parser aliases. Use `--json` or `--toon` directly.
+
+### Added
+
+- Routed projects, releases, incidents, and outer workflows through generated OpenAPI operations instead of hand-built request paths, so workflow definitions stay tied to operation IDs.
+- Split per-surface workflow modules (incidents, projects, releases, access, integrations, protocol-manager, events, search, and related surfaces) so adding a new API-backed workflow now has an obvious file and pattern.
+- Added a build-time OpenAPI spec transform that prunes the generated client surface before progenitor runs.
+
+### Changed
+
+- Improved default human-mode CLI output without changing the `--toon` / `--json` machine contracts; help, parse, auth, workflow, and destructive-command output now stay mode-aware.
+- Split the raw `pcl api` command internals by concern (list, inspect, call, coverage, manifest) and refactored CLI output contracts and workflow subcommands on top of the human-output work.
+- Refactored workflow/action metadata into clearer contract definitions, keeping schema and manifest output aligned with top-level workflow commands.
+- Preserved structured `ErrorResponse` / `UnexpectedResponse` payloads from the generated client in `apply` preview, release, and download paths instead of stringifying errors.
+
+### Removed
+
+- Removed stale raw API aliases, the old manual workflow request constructors, and workflow surface that no longer belongs in the product path.
+
 ## 1.4.4 - 2026-05-12
 
 - Fixed expired-auth recovery guidance so human output recommends `pcl auth refresh` before forcing a new login, while TOON/JSON next actions keep their explicit output modes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -7472,7 +7472,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -7506,7 +7506,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.4.4"
+version = "1.5.0"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.4"
+version = "1.5.0"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"


### PR DESCRIPTION
Bumps the workspace to **1.5.0** and adds the changelog entry summarizing the stack just landed (#96 → #98 → #100 → #101 → #102 + hotfix #104).

When this merges, `Cargo.toml` changes on `main`, which triggers `Tag, Release and Publish` to cut the `1.5.0` tag and publish the release.

## Summary
- Breaking: `pcl transfers` removed; hidden legacy `--format` alias removed.
- Generated-client routing for projects/releases/incidents/outer workflows; pruned generated client surface via build-time OpenAPI transform.
- Workflow layer split per-surface; clearer contract definitions; structured API error payloads preserved end-to-end.
- Human-mode CLI output polish without changing `--toon`/`--json` machine contracts.

## Test plan
- [ ] `Rust Test & Lint` + `Release Feature Check` green
- [ ] Tag `1.5.0` is created by the release workflow after merge