### PR TITLE
[codex] route CI jobs to ARC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ env:
 jobs:
   runner-git-config:
     name: Runner Git Config Preflight
-    runs-on: phylax-self-hosted
+    runs-on: phylax-ubuntu-latitude
     steps:
       - name: Remove leaked GitHub SSH rewrites
         run: |
@@ -60,7 +60,7 @@ jobs:
     needs: runner-git-config
     uses: phylaxsystems/actions/.github/workflows/rust-base.yaml@main
     with:
-      runner: "phylax-self-hosted"
+      runner: "phylax-ubuntu-latitude"
       rust-channel: "nightly-2026-01-07"
       require-lockfile: true
       requires-private-deps: true
@@ -77,7 +77,7 @@ jobs:
     name: Release Feature Check
     needs: runner-git-config
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: phylax-self-hosted
+    runs-on: phylax-ubuntu-latitude
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       GIT_CONFIG_GLOBAL: /tmp/pcl-release-feature-${{ github.run_id }}-${{ github.run_attempt }}.gitconfig
@@ -104,7 +104,7 @@ jobs:
   agent-smoke:
     name: Agent CLI Smoke
     needs: [runner-git-config, release-feature-check]
-    runs-on: phylax-self-hosted
+    runs-on: phylax-ubuntu-latitude
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       GIT_CONFIG_GLOBAL: /tmp/pcl-agent-smoke-${{ github.run_id }}-${{ github.run_attempt }}.gitconfig

--- a/.github/workflows/regenerate-dapp-client.yaml
+++ b/.github/workflows/regenerate-dapp-client.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   regenerate:
     name: Regenerate dapp-api-client
-    runs-on: phylax-self-hosted
+    runs-on: phylax-ubuntu-latitude
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What changed

- Route all PCL self-hosted CI jobs to the `phylax-ubuntu-latitude` ARC scale set.
- Route the scheduled dApp client regeneration job to the same ARC pool.

## Why

Latitude's eight long-lived systemd GitHub runners have been stopped and disabled. ARC is now the machine's primary CI/CD runner pool, with a 12-runner ceiling and NVMe-backed work/cache storage.

## Validation

- `git diff --check`
- `actionlint` (ignoring only its unknown-organization-label diagnostic for `phylax-ubuntu-latitude`)
- `make ci`: formatting, clippy, and full workspace check passed; the local run then stopped during the release-check build because the Mac ran out of disk space. This PR's CI is the authoritative full run on ARC.