### PR TITLE
feat(projects): upload a local profile image via --profile-image

### DIFF
--- a/crates/pcl/cli/src/cli.rs
+++ b/crates/pcl/cli/src/cli.rs
@@ -346,6 +346,53 @@ mod tests {
     }
 
     #[test]
+    fn parses_project_image_options_and_enforces_conflicts() {
+        // Uploading a local image file parses on create.
+        let create = Cli::try_parse_from([
+            "pcl",
+            "projects",
+            "create",
+            "--project-name",
+            "demo",
+            "--chain-id",
+            "1",
+            "--profile-image",
+            "./logo.png",
+        ])
+        .unwrap();
+        assert!(matches!(create.command, Commands::Projects(_)));
+
+        // Removing the image parses on update.
+        let update = Cli::try_parse_from([
+            "pcl",
+            "projects",
+            "update",
+            "demo",
+            "--remove-profile-image",
+        ])
+        .unwrap();
+        assert!(matches!(update.command, Commands::Projects(_)));
+
+        // --profile-image and --profile-image-url are mutually exclusive.
+        let conflict = Cli::try_parse_from([
+            "pcl",
+            "projects",
+            "create",
+            "--project-name",
+            "demo",
+            "--chain-id",
+            "1",
+            "--profile-image",
+            "./logo.png",
+            "--profile-image-url",
+            "https://example.com/logo.png",
+        ])
+        .err()
+        .expect("expected --profile-image/--profile-image-url conflict");
+        assert_eq!(conflict.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
     fn parses_agent_product_surface_commands() {
         assert!(matches!(
             Cli::try_parse_from(["pcl", "doctor", "--offline"])

--- a/crates/pcl/core/Cargo.toml
+++ b/crates/pcl/core/Cargo.toml
@@ -35,7 +35,7 @@ colored = { workspace = true }
 sha2 = { workspace = true }
 
 # other deps
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "multipart"] }
 inquire = "0.9"
 toml = "0.8.2"
 dirs = "6.0.0"

--- a/crates/pcl/core/src/api.rs
+++ b/crates/pcl/core/src/api.rs
@@ -395,7 +395,7 @@ struct IncidentsArgs {
     jsonl: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct ProjectsArgs {
     project_id: Option<String>,
     mine: bool,
@@ -414,6 +414,11 @@ struct ProjectsArgs {
     project_name: Option<String>,
     project_description: Option<String>,
     profile_image_url: Option<String>,
+    /// Local image file to upload and set as the project image. Resolved to a
+    /// storage path before the create/update request is built.
+    profile_image: Option<PathBuf>,
+    /// Clear the project image by sending `profile_image_url: null`.
+    remove_profile_image: bool,
     github_url: Option<String>,
     chain_id: Option<u64>,
     is_private: Option<bool>,
@@ -427,7 +432,7 @@ struct ProjectsArgs {
 #[derive(clap::Args, Debug)]
 #[command(
     about = "List, inspect, create, update, save, or delete projects",
-    after_help = "Examples:\n  pcl projects mine\n  pcl projects list\n  pcl projects show <project-ref>\n  pcl projects saved --user-id <user-id>\n  pcl projects create --project-name demo --chain-id 1\n  pcl projects update <project-ref> --field github_url=https://github.com/org/repo\n  pcl projects save <project-ref>"
+    after_help = "Examples:\n  pcl projects mine\n  pcl projects list\n  pcl projects show <project-ref>\n  pcl projects saved --user-id <user-id>\n  pcl projects create --project-name demo --chain-id 1\n  pcl projects create --project-name demo --chain-id 1 --profile-image ./logo.png\n  pcl projects update <project-ref> --profile-image ./logo.png\n  pcl projects update <project-ref> --remove-profile-image\n  pcl projects update <project-ref> --field github_url=https://github.com/org/repo\n  pcl projects save <project-ref>"
 )]
 pub struct ProjectsCommand {
     #[command(flatten)]
@@ -498,8 +503,24 @@ struct ProjectWriteArgs {
     project_name: Option<String>,
     #[arg(long, help = "Project description")]
     project_description: Option<String>,
-    #[arg(long, help = "Project profile image URL")]
+    #[arg(
+        long,
+        help = "Project profile image URL or storage path (already hosted)"
+    )]
     profile_image_url: Option<String>,
+    #[arg(
+        long,
+        value_name = "FILE",
+        conflicts_with_all = ["profile_image_url", "remove_profile_image"],
+        help = "Upload a local image file (png/jpeg/webp/svg, max 5 MB) and set it as the project image"
+    )]
+    profile_image: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with_all = ["profile_image_url", "profile_image"],
+        help = "Remove the current project image"
+    )]
+    remove_profile_image: bool,
     #[arg(long, help = "Project GitHub URL")]
     github_url: Option<String>,
     #[arg(long, help = "Chain ID for create")]
@@ -629,6 +650,8 @@ impl ProjectWriteArgs {
         args.project_name = self.project_name;
         args.project_description = self.project_description;
         args.profile_image_url = self.profile_image_url;
+        args.profile_image = self.profile_image;
+        args.remove_profile_image = self.remove_profile_image;
         args.github_url = self.github_url;
         args.chain_id = self.chain_id;
         args.is_private = self.is_private;

--- a/crates/pcl/core/src/api/runner.rs
+++ b/crates/pcl/core/src/api/runner.rs
@@ -700,7 +700,7 @@ impl ApiArgs {
             self.ensure_request_auth(config, cli_args, request.require_auth)
                 .await?;
             let storage_path = self
-                .upload_project_image(config, image_path, request_log_path)
+                .upload_project_image(config, cli_args, image_path, request_log_path)
                 .await?;
             let mut body = request
                 .body
@@ -734,7 +734,8 @@ impl ApiArgs {
     /// multipart `file` to `/storage/upload`, and read back `{ "path": ... }`.
     pub(in crate::api) async fn upload_project_image(
         &self,
-        config: &CliConfig,
+        config: &mut CliConfig,
+        cli_args: &CliArgs,
         image_path: &Path,
         request_log_path: &Path,
     ) -> Result<String, ApiCommandError> {
@@ -804,15 +805,30 @@ impl ApiArgs {
             .and_then(|name| name.to_str())
             .unwrap_or("image")
             .to_string();
-        let part = reqwest::multipart::Part::bytes(bytes)
-            .file_name(file_name)
-            .mime_str(mime)?;
-        let form = reqwest::multipart::Form::new().part("file", part);
 
         let requires_auth = !self.allow_unauthenticated;
-        let client = self.http_client(config, requires_auth, requires_auth)?;
         let url = self.api_url("/storage/upload")?;
-        let payload = read_api_response(client.post(url).multipart(form).send().await?).await?;
+
+        // A `reqwest` multipart form is a single-use stream, so both the first
+        // attempt and any post-refresh retry need a freshly built form.
+        // Rebuilding the client on retry also picks up a token that
+        // `try_refresh_after_401` swapped into `config`.
+        let build_form = || -> Result<reqwest::multipart::Form, ApiCommandError> {
+            let part = reqwest::multipart::Part::bytes(bytes.clone())
+                .file_name(file_name.clone())
+                .mime_str(mime)?;
+            Ok(reqwest::multipart::Form::new().part("file", part))
+        };
+
+        let client = self.http_client(config, requires_auth, requires_auth)?;
+        let mut payload = read_api_response(
+            client
+                .post(url.clone())
+                .multipart(build_form()?)
+                .send()
+                .await?,
+        )
+        .await?;
         write_request_log(
             request_log_path,
             "storage_upload",
@@ -822,6 +838,34 @@ impl ApiArgs {
             payload.request_id.as_deref(),
             None,
         );
+
+        // Mirror `call_workflow_result`/`call_api`: a 401 on a locally-unexpired
+        // token that the server rejects can still be recovered by refreshing and
+        // retrying once. `ensure_request_auth` earlier only covers expired tokens.
+        if payload.status.as_u16() == 401
+            && requires_auth
+            && self.try_refresh_after_401(config, cli_args).await?
+        {
+            let client = self.http_client(config, requires_auth, requires_auth)?;
+            payload = read_api_response(
+                client
+                    .post(url.clone())
+                    .multipart(build_form()?)
+                    .send()
+                    .await?,
+            )
+            .await?;
+            write_request_log(
+                request_log_path,
+                "storage_upload_retry_after_refresh",
+                "POST",
+                "/storage/upload",
+                payload.status.as_u16(),
+                payload.request_id.as_deref(),
+                None,
+            );
+        }
+
         if !payload.status.is_success() {
             return Err(ApiCommandError::HttpStatus {
                 method: "POST",

--- a/crates/pcl/core/src/api/runner.rs
+++ b/crates/pcl/core/src/api/runner.rs
@@ -96,6 +96,23 @@ use serde_json::{
 };
 use std::path::Path;
 
+/// Maximum accepted project image size, matching the dApp upload limit (5 MB).
+const MAX_IMAGE_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Map a local image file's extension to the MIME type the storage endpoint
+/// accepts. Returns `None` for unsupported extensions. Kept in sync with the
+/// dApp's `ALLOWED_IMAGE_MIME_TYPES`.
+fn image_mime_for_path(path: &Path) -> Option<&'static str> {
+    let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+    match extension.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "svg" => Some("image/svg+xml"),
+        _ => None,
+    }
+}
+
 fn generated_error_request_id<E>(error: &GeneratedError<E>) -> Option<String> {
     match error {
         GeneratedError::ErrorResponse(response) => request_id_from_headers(response.headers()),
@@ -668,7 +685,20 @@ impl ApiArgs {
         if args.body_template {
             return Ok(template_envelope(project_body_template(args)));
         }
-        let request = projects_request(args)?;
+        // A `--profile-image <FILE>` upload has to happen before the request body
+        // is built: the storage endpoint returns a path that becomes the
+        // `profile_image_url` on the create/update request.
+        let request = if let Some(image_path) = &args.profile_image {
+            let storage_path = self
+                .upload_project_image(config, image_path, request_log_path)
+                .await?;
+            let mut args = args.clone();
+            args.profile_image = None;
+            args.profile_image_url = Some(storage_path);
+            projects_request(&args)?
+        } else {
+            projects_request(args)?
+        };
         self.run_prepared_workflow(
             config,
             cli_args,
@@ -678,6 +708,88 @@ impl ApiArgs {
             projects_next_actions,
         )
         .await
+    }
+
+    /// Upload a local image file to the storage endpoint and return the storage
+    /// path the API stores as `profile_image_url`.
+    ///
+    /// Mirrors the dApp's create/settings flow: validate the file, POST it as
+    /// multipart `file` to `/storage/upload`, and read back `{ "path": ... }`.
+    pub(in crate::api) async fn upload_project_image(
+        &self,
+        config: &CliConfig,
+        image_path: &Path,
+        request_log_path: &Path,
+    ) -> Result<String, ApiCommandError> {
+        let mime = image_mime_for_path(image_path).ok_or_else(|| {
+            ApiCommandError::InvalidWorkflow {
+                message: format!(
+                    "Unsupported image `{}`. Allowed types: png, jpg, jpeg, webp, svg",
+                    image_path.display()
+                ),
+            }
+        })?;
+        let bytes = std::fs::read(image_path).map_err(|source| {
+            ApiCommandError::InvalidWorkflow {
+                message: format!(
+                    "Failed to read image file `{}`: {source}",
+                    image_path.display()
+                ),
+            }
+        })?;
+        if bytes.len() as u64 > MAX_IMAGE_FILE_SIZE_BYTES {
+            return Err(ApiCommandError::InvalidWorkflow {
+                message: format!(
+                    "Image file `{}` is {} bytes; maximum is {} bytes (5 MB)",
+                    image_path.display(),
+                    bytes.len(),
+                    MAX_IMAGE_FILE_SIZE_BYTES
+                ),
+            });
+        }
+
+        let file_name = image_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("image")
+            .to_string();
+        let part = reqwest::multipart::Part::bytes(bytes)
+            .file_name(file_name)
+            .mime_str(mime)?;
+        let form = reqwest::multipart::Form::new().part("file", part);
+
+        let requires_auth = !self.allow_unauthenticated;
+        let client = self.http_client(config, requires_auth, requires_auth)?;
+        let url = self.api_url("/storage/upload")?;
+        let payload = read_api_response(client.post(url).multipart(form).send().await?).await?;
+        write_request_log(
+            request_log_path,
+            "storage_upload",
+            "POST",
+            "/storage/upload",
+            payload.status.as_u16(),
+            payload.request_id.as_deref(),
+            None,
+        );
+        if !payload.status.is_success() {
+            return Err(ApiCommandError::HttpStatus {
+                method: "POST",
+                path: "/storage/upload".to_string(),
+                status: payload.status.as_u16(),
+                request_id: payload.request_id,
+                body: Box::new(payload.body),
+            });
+        }
+        payload
+            .body
+            .get("path")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .ok_or_else(|| {
+                ApiCommandError::InvalidWorkflow {
+                    message: "Image upload response did not include a storage path".to_string(),
+                }
+            })
     }
 
     pub(in crate::api) async fn run_assertions(

--- a/crates/pcl/core/src/api/runner.rs
+++ b/crates/pcl/core/src/api/runner.rs
@@ -94,7 +94,10 @@ use serde_json::{
     Value,
     json,
 };
-use std::path::Path;
+use std::{
+    io::Read as _,
+    path::Path,
+};
 
 /// Maximum accepted project image size, matching the dApp upload limit (5 MB).
 const MAX_IMAGE_FILE_SIZE_BYTES: u64 = 5 * 1024 * 1024;
@@ -685,20 +688,34 @@ impl ApiArgs {
         if args.body_template {
             return Ok(template_envelope(project_body_template(args)));
         }
-        // A `--profile-image <FILE>` upload has to happen before the request body
-        // is built: the storage endpoint returns a path that becomes the
-        // `profile_image_url` on the create/update request.
-        let request = if let Some(image_path) = &args.profile_image {
+        // Build and validate the project request before the upload. This keeps
+        // malformed body/field input from creating an orphaned storage object,
+        // and lets us patch the returned path into the already-read body (which
+        // matters for `--body-file -`: stdin can only be consumed once).
+        let mut request = projects_request(args)?;
+        if let Some(image_path) = &args.profile_image {
+            // The upload is a separate authenticated request, so refresh an
+            // expired/expiring CLI token before sending it. The project call
+            // below performs the same check again, harmlessly, after upload.
+            self.ensure_request_auth(config, cli_args, request.require_auth)
+                .await?;
             let storage_path = self
                 .upload_project_image(config, image_path, request_log_path)
                 .await?;
-            let mut args = args.clone();
-            args.profile_image = None;
-            args.profile_image_url = Some(storage_path);
-            projects_request(&args)?
-        } else {
-            projects_request(args)?
-        };
+            let mut body = request
+                .body
+                .as_deref()
+                .map(serde_json::from_str::<Value>)
+                .transpose()?
+                .unwrap_or_else(|| json!({}));
+            let object = body.as_object_mut().ok_or_else(|| {
+                ApiCommandError::InvalidWorkflow {
+                    message: "project body must be a JSON object".to_string(),
+                }
+            })?;
+            object.insert("profile_image_url".to_string(), Value::String(storage_path));
+            request.body = Some(body.to_string());
+        }
         self.run_prepared_workflow(
             config,
             cli_args,
@@ -729,7 +746,7 @@ impl ApiArgs {
                 ),
             }
         })?;
-        let bytes = std::fs::read(image_path).map_err(|source| {
+        let file = std::fs::File::open(image_path).map_err(|source| {
             ApiCommandError::InvalidWorkflow {
                 message: format!(
                     "Failed to read image file `{}`: {source}",
@@ -737,12 +754,46 @@ impl ApiArgs {
                 ),
             }
         })?;
-        if bytes.len() as u64 > MAX_IMAGE_FILE_SIZE_BYTES {
+        let declared_size = file
+            .metadata()
+            .map_err(|source| {
+                ApiCommandError::InvalidWorkflow {
+                    message: format!(
+                        "Failed to inspect image file `{}`: {source}",
+                        image_path.display()
+                    ),
+                }
+            })?
+            .len();
+        if declared_size > MAX_IMAGE_FILE_SIZE_BYTES {
             return Err(ApiCommandError::InvalidWorkflow {
                 message: format!(
                     "Image file `{}` is {} bytes; maximum is {} bytes (5 MB)",
                     image_path.display(),
-                    bytes.len(),
+                    declared_size,
+                    MAX_IMAGE_FILE_SIZE_BYTES
+                ),
+            });
+        }
+        // Do not trust metadata alone: a file can grow between metadata() and
+        // read(), and special files may report a zero length. Read at most one
+        // byte beyond the limit so the CLI never allocates an unbounded input.
+        let mut bytes = Vec::with_capacity(usize::try_from(declared_size).unwrap_or(0));
+        file.take(MAX_IMAGE_FILE_SIZE_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|source| {
+                ApiCommandError::InvalidWorkflow {
+                    message: format!(
+                        "Failed to read image file `{}`: {source}",
+                        image_path.display()
+                    ),
+                }
+            })?;
+        if bytes.len() as u64 > MAX_IMAGE_FILE_SIZE_BYTES {
+            return Err(ApiCommandError::InvalidWorkflow {
+                message: format!(
+                    "Image file `{}` exceeds the maximum of {} bytes (5 MB)",
+                    image_path.display(),
                     MAX_IMAGE_FILE_SIZE_BYTES
                 ),
             });

--- a/crates/pcl/core/src/api/tests.rs
+++ b/crates/pcl/core/src/api/tests.rs
@@ -144,6 +144,8 @@ fn projects_args() -> ProjectsArgs {
         project_name: None,
         project_description: None,
         profile_image_url: None,
+        profile_image: None,
+        remove_profile_image: false,
         github_url: None,
         chain_id: None,
         is_private: None,
@@ -1460,6 +1462,90 @@ fn builds_project_create_body_from_typed_flags() {
             "is_private": false
         })
     );
+}
+
+#[test]
+fn builds_project_body_with_profile_image_url() {
+    let request = projects_request(&ProjectsArgs {
+        create: true,
+        project_name: Some("Demo".to_string()),
+        chain_id: Some(1),
+        profile_image_url: Some("https://example.com/logo.png".to_string()),
+        ..projects_args()
+    })
+    .unwrap();
+
+    assert_eq!(
+        serde_json::from_str::<Value>(request.body.as_deref().unwrap()).unwrap(),
+        json!({
+            "project_name": "Demo",
+            "chain_id": 1,
+            "profile_image_url": "https://example.com/logo.png"
+        })
+    );
+}
+
+#[test]
+fn removing_project_image_sends_explicit_null() {
+    let request = projects_request(&ProjectsArgs {
+        project_id: Some("project-1".to_string()),
+        update: true,
+        remove_profile_image: true,
+        ..projects_args()
+    })
+    .unwrap();
+
+    assert_eq!(request.method.openapi_key(), "put");
+    assert_eq!(
+        serde_json::from_str::<Value>(request.body.as_deref().unwrap()).unwrap(),
+        json!({ "profile_image_url": null })
+    );
+}
+
+#[tokio::test]
+async fn uploads_project_image_and_returns_storage_path() {
+    let mut server = mockito::Server::new_async().await;
+    let upload = server
+        .mock("POST", "/api/v1/storage/upload")
+        .match_header("authorization", "Bearer access-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"path":"projects/0xabc/logo.png"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let api = test_api(server.url(), false);
+    let mut config = valid_auth_config("access-token", "refresh-token");
+    config.platform_url = Some(server.url());
+
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("logo.png");
+    std::fs::write(&image, b"not-a-real-png-but-fine-for-upload").unwrap();
+
+    let path = api
+        .upload_project_image(&config, &image, test_request_log_path())
+        .await
+        .unwrap();
+
+    assert_eq!(path, "projects/0xabc/logo.png");
+    upload.assert_async().await;
+}
+
+#[tokio::test]
+async fn upload_rejects_unsupported_image_extension() {
+    let api = test_api("http://127.0.0.1:0", false);
+    let config = valid_auth_config("access-token", "refresh-token");
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("logo.gif");
+    std::fs::write(&image, b"gif").unwrap();
+
+    let error = api
+        .upload_project_image(&config, &image, test_request_log_path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), "workflow.invalid_arguments");
+    assert!(error.to_string().contains("png, jpg, jpeg, webp, svg"));
 }
 
 #[test]

--- a/crates/pcl/core/src/api/tests.rs
+++ b/crates/pcl/core/src/api/tests.rs
@@ -1523,7 +1523,12 @@ async fn uploads_project_image_and_returns_storage_path() {
     std::fs::write(&image, b"not-a-real-png-but-fine-for-upload").unwrap();
 
     let path = api
-        .upload_project_image(&config, &image, test_request_log_path())
+        .upload_project_image(
+            &mut config,
+            &CliArgs::default(),
+            &image,
+            test_request_log_path(),
+        )
         .await
         .unwrap();
 
@@ -1600,6 +1605,69 @@ async fn project_image_upload_refreshes_auth_before_the_multipart_request() {
 }
 
 #[tokio::test]
+async fn project_image_upload_refreshes_and_retries_after_401() {
+    let mut server = mockito::Server::new_async().await;
+    let first_attempt = server
+        .mock("POST", "/api/v1/storage/upload")
+        .match_header("authorization", "Bearer old-access")
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"code":"TOKEN_EXPIRED","error":"expired"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let refresh = server
+        .mock("POST", "/api/v1/auth/refresh")
+        .match_body(Matcher::Json(json!({ "refresh_token": "old-refresh" })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"token":"new-access","refresh_token":"new-refresh","expires_at":"2030-01-01T00:00:00Z","refresh_expires_at":"2030-02-01T00:00:00Z"}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let retry = server
+        .mock("POST", "/api/v1/storage/upload")
+        .match_header("authorization", "Bearer new-access")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"path":"projects/0xabc/logo.png"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let api = test_api(server.url(), false);
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cli_args = CliArgs {
+        config_dir: Some(temp_dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    // A locally-unexpired token (2030) that the server nonetheless rejects: the
+    // proactive `ensure_request_auth` check leaves it untouched, so only a
+    // reactive refresh-on-401 can recover.
+    let mut config = valid_auth_config("old-access", "old-refresh");
+    config.platform_url = Some(server.url());
+    config.write_to_file(&cli_args).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("logo.png");
+    std::fs::write(&image, b"not-a-real-png-but-fine-for-upload").unwrap();
+
+    let path = api
+        .upload_project_image(&mut config, &cli_args, &image, test_request_log_path())
+        .await
+        .unwrap();
+
+    assert_eq!(path, "projects/0xabc/logo.png");
+    assert_eq!(config.auth.as_ref().unwrap().access_token, "new-access");
+    assert_eq!(config.auth.as_ref().unwrap().refresh_token, "new-refresh");
+    first_attempt.assert_async().await;
+    refresh.assert_async().await;
+    retry.assert_async().await;
+}
+
+#[tokio::test]
 async fn malformed_project_body_fails_before_image_upload() {
     let mut server = mockito::Server::new_async().await;
     let upload = server
@@ -1638,13 +1706,18 @@ async fn malformed_project_body_fails_before_image_upload() {
 #[tokio::test]
 async fn upload_rejects_unsupported_image_extension() {
     let api = test_api("http://127.0.0.1:0", false);
-    let config = valid_auth_config("access-token", "refresh-token");
+    let mut config = valid_auth_config("access-token", "refresh-token");
     let dir = tempfile::tempdir().unwrap();
     let image = dir.path().join("logo.gif");
     std::fs::write(&image, b"gif").unwrap();
 
     let error = api
-        .upload_project_image(&config, &image, test_request_log_path())
+        .upload_project_image(
+            &mut config,
+            &CliArgs::default(),
+            &image,
+            test_request_log_path(),
+        )
         .await
         .unwrap_err();
 
@@ -1655,7 +1728,7 @@ async fn upload_rejects_unsupported_image_extension() {
 #[tokio::test]
 async fn upload_rejects_an_oversized_file_without_reading_it_into_memory() {
     let api = test_api("http://127.0.0.1:0", false);
-    let config = valid_auth_config("access-token", "refresh-token");
+    let mut config = valid_auth_config("access-token", "refresh-token");
     let dir = tempfile::tempdir().unwrap();
     let image = dir.path().join("huge.png");
     std::fs::File::create(&image)
@@ -1664,7 +1737,12 @@ async fn upload_rejects_an_oversized_file_without_reading_it_into_memory() {
         .unwrap();
 
     let error = api
-        .upload_project_image(&config, &image, test_request_log_path())
+        .upload_project_image(
+            &mut config,
+            &CliArgs::default(),
+            &image,
+            test_request_log_path(),
+        )
         .await
         .unwrap_err();
 

--- a/crates/pcl/core/src/api/tests.rs
+++ b/crates/pcl/core/src/api/tests.rs
@@ -1532,6 +1532,110 @@ async fn uploads_project_image_and_returns_storage_path() {
 }
 
 #[tokio::test]
+async fn project_image_upload_refreshes_auth_before_the_multipart_request() {
+    let mut server = mockito::Server::new_async().await;
+    let refresh = server
+        .mock("POST", "/api/v1/auth/refresh")
+        .match_body(Matcher::Json(json!({ "refresh_token": "old-refresh" })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"token":"new-access","refresh_token":"new-refresh","expires_at":"2030-01-01T00:00:00Z","refresh_expires_at":"2030-02-01T00:00:00Z"}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let upload = server
+        .mock("POST", "/api/v1/storage/upload")
+        .match_header("authorization", "Bearer new-access")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"path":"projects/user/logo.png"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let project_id = "550e8400-e29b-41d4-a716-446655440000";
+    let update = server
+        .mock("PUT", format!("/api/v1/projects/{project_id}").as_str())
+        .match_header("authorization", "Bearer new-access")
+        .match_body(Matcher::Json(json!({
+            "profile_image_url": "projects/user/logo.png"
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"id":"{project_id}"}}"#))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let api = test_api(server.url(), false);
+    let config_dir = tempfile::tempdir().unwrap();
+    let cli_args = CliArgs {
+        config_dir: Some(config_dir.path().to_path_buf()),
+        ..CliArgs::default()
+    };
+    let mut config = expired_auth_config("old-access", "old-refresh");
+    config.platform_url = Some(server.url());
+    config.write_to_file(&cli_args).unwrap();
+    let image_dir = tempfile::tempdir().unwrap();
+    let image = image_dir.path().join("logo.png");
+    std::fs::write(&image, b"png").unwrap();
+    let args = ProjectsArgs {
+        project_id: Some(project_id.to_string()),
+        update: true,
+        profile_image: Some(image),
+        ..projects_args()
+    };
+
+    let result = api
+        .run_projects(&mut config, &cli_args, &args, test_request_log_path())
+        .await
+        .unwrap();
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(config.auth.as_ref().unwrap().access_token, "new-access");
+    refresh.assert_async().await;
+    upload.assert_async().await;
+    update.assert_async().await;
+}
+
+#[tokio::test]
+async fn malformed_project_body_fails_before_image_upload() {
+    let mut server = mockito::Server::new_async().await;
+    let upload = server
+        .mock("POST", "/api/v1/storage/upload")
+        .expect(0)
+        .create_async()
+        .await;
+    let api = test_api(server.url(), false);
+    let mut config = valid_auth_config("access-token", "refresh-token");
+    config.platform_url = Some(server.url());
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("logo.png");
+    std::fs::write(&image, b"png").unwrap();
+    let args = ProjectsArgs {
+        project_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        update: true,
+        profile_image: Some(image),
+        body: Some("[not-json".to_string()),
+        ..projects_args()
+    };
+
+    let error = api
+        .run_projects(
+            &mut config,
+            &CliArgs::default(),
+            &args,
+            test_request_log_path(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), "input.invalid_json");
+    upload.assert_async().await;
+}
+
+#[tokio::test]
 async fn upload_rejects_unsupported_image_extension() {
     let api = test_api("http://127.0.0.1:0", false);
     let config = valid_auth_config("access-token", "refresh-token");
@@ -1546,6 +1650,26 @@ async fn upload_rejects_unsupported_image_extension() {
 
     assert_eq!(error.code(), "workflow.invalid_arguments");
     assert!(error.to_string().contains("png, jpg, jpeg, webp, svg"));
+}
+
+#[tokio::test]
+async fn upload_rejects_an_oversized_file_without_reading_it_into_memory() {
+    let api = test_api("http://127.0.0.1:0", false);
+    let config = valid_auth_config("access-token", "refresh-token");
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("huge.png");
+    std::fs::File::create(&image)
+        .unwrap()
+        .set_len(5 * 1024 * 1024 + 1)
+        .unwrap();
+
+    let error = api
+        .upload_project_image(&config, &image, test_request_log_path())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), "workflow.invalid_arguments");
+    assert!(error.to_string().contains("maximum is 5242880 bytes"));
 }
 
 #[test]

--- a/crates/pcl/core/src/api/workflows.rs
+++ b/crates/pcl/core/src/api/workflows.rs
@@ -182,6 +182,11 @@ fn project_request_body(args: &ProjectsArgs) -> Result<Option<String>, ApiComman
         "profile_image_url",
         args.profile_image_url.clone().map(Value::String),
     );
+    // `--remove-profile-image` clears the image by sending an explicit null,
+    // which `insert_optional` cannot express.
+    if args.remove_profile_image {
+        map.insert("profile_image_url".to_string(), Value::Null);
+    }
     insert_optional(
         map,
         "github_url",


### PR DESCRIPTION
## What

Adds project profile-image management to the CLI:

- **`pcl projects create|update --profile-image <FILE>`** — validates the file (png/jpeg/webp/svg, ≤ 5 MB), uploads it as multipart `file` to `POST /api/v1/storage/upload`, and sets the returned storage path as the project's `profile_image_url`.
- **`pcl projects update --remove-profile-image`** — clears the image by sending an explicit `profile_image_url: null`.
- `--profile-image`, `--profile-image-url` (pre-hosted path, pre-existing), and `--remove-profile-image` are mutually exclusive (enforced by clap).

## Why / dependency

This is the CLI half of the storage-upload work. The upload path requires a dApp that accepts app-issued CLI tokens at `/storage/upload` — added in **phylaxsystems/credible-layer-dapp#1231** (merged). Against an older dApp, `--profile-image` returns 401; `--profile-image-url` and `--remove-profile-image` work regardless.

## Notes

- Enables reqwest's `multipart` feature (no `Cargo.lock` change — deps were already present).
- Client-side validation (type + 5 MB cap) mirrors the dApp's limits, so obvious errors fail before any network call.

## Testing

- Unit: clap parse/conflict test (`cli.rs`) and request-body tests (`api/`).
- End-to-end against a local devstack: `--profile-image` → HTTP 200 with the object written to the `project-images` bucket and `profile_image_url` persisted; `--remove-profile-image` → column cleared to NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
