### PR TITLE
fix(apply): render assertion changes under unchanged contracts

### DIFF
--- a/crates/pcl/core/src/diff.rs
+++ b/crates/pcl/core/src/diff.rs
@@ -201,6 +201,11 @@ fn render_unchanged(out: &mut String, label: &str, entry: &ContractDiffEntry) {
         format!("contract \"{name}\" (unchanged)").dimmed(),
     )
     .unwrap();
+    // A contract is "unchanged" when its metadata (name/address) is untouched,
+    // but its assertions may still have changed — render those like the dApp does.
+    for a in &entry.assertions {
+        render_assertion_diff(out, a);
+    }
     writeln!(out).unwrap();
 }
 
@@ -711,6 +716,55 @@ mod tests {
         assert!(output.contains("- Old.sol"));
         assert!(!output.contains("name:"));
         assert!(!output.contains("address:"));
+    }
+
+    #[test]
+    fn renders_unchanged_contract_with_assertion_changes() {
+        disable_colors();
+
+        // The canonical diff (compute-release-diff.ts) marks a contract
+        // "unchanged" when its name/address are untouched, even if its
+        // assertions were added/removed/modified. Those nested changes must
+        // still be rendered, matching the dApp release-detail UI.
+        let json = json!({
+            "hasChanges": true,
+            "configMismatch": false,
+            "driftDetected": false,
+            "diff": {
+                "contracts": {
+                    "stable": {
+                        "address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "name": "Stable",
+                        "changeType": "unchanged",
+                        "metadataChanges": null,
+                        "assertions": [
+                            { "file": "New.a.sol", "args": [], "changeType": "added", "assertionId": "0x1", "previousAssertionId": null, "compilerVersionChange": null },
+                            { "file": "Old.a.sol", "args": [], "changeType": "removed", "assertionId": null, "previousAssertionId": "0x2", "compilerVersionChange": null },
+                            { "file": "Tweaked.a.sol", "args": [], "changeType": "modified", "assertionId": "0x3", "previousAssertionId": "0x4", "compilerVersionChange": { "from": "0.8.20", "to": "0.8.24" } },
+                            { "file": "Untouched.a.sol", "args": [], "changeType": "unchanged", "assertionId": "0x5", "previousAssertionId": null, "compilerVersionChange": null }
+                        ]
+                    }
+                },
+                "summary": {
+                    "contracts": { "added": 0, "removed": 0, "modified": 0, "unchanged": 1 },
+                    "assertions": { "added": 1, "removed": 1, "modified": 1, "unchanged": 1 }
+                }
+            },
+            "diffedAgainstReleaseId": null
+        });
+
+        let preview: PreviewResponse = serde_json::from_value(json).unwrap();
+        let output = preview.render_plan();
+
+        assert!(output.contains("contract \"Stable\" (unchanged)"));
+        assert!(output.contains("+ New.a.sol"));
+        assert!(output.contains("- Old.a.sol"));
+        assert!(output.contains("~ Tweaked.a.sol"));
+        assert!(output.contains("compiler: 0.8.20 \u{2192} 0.8.24"));
+        // Unchanged assertions stay hidden, as in every other contract group.
+        assert!(!output.contains("Untouched.a.sol"));
+        // Rendered detail now agrees with the assertion-level summary.
+        assert!(output.contains("Plan: 1 added, 1 changed, 1 removed."));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`pcl apply`'s deployment plan could hide real changes. The canonical release diff (`compute-release-diff.ts` in credible-layer-dapp) derives a contract's `changeType` only from its metadata (name/address) — so a contract whose assertions were added, removed, or modified but whose metadata is untouched is marked `unchanged`, with the changes carried in its nested `assertions` array. `render_unchanged()` dropped those entries entirely, producing output like:

```
  contract "Stable" (unchanged)

Plan: 1 added, 1 changed, 1 removed.
```

— a summary counting changes that were nowhere in the visible plan.

## Fix

Render assertion diffs under unchanged contract headers using the existing `render_assertion_diff()`, matching the dApp release-detail UI (which renders every contract card with all nested assertion rows regardless of the contract's own change type). Unchanged assertions stay hidden, consistent with the other contract groups.

## Testing

- New regression test `renders_unchanged_contract_with_assertion_changes`: an unchanged contract with added/removed/modified/unchanged assertions renders all changed rows, hides the unchanged one, and agrees with the plan summary.
- All 14 `diff::` tests pass; clippy and fmt clean on `pcl-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)