### PR TITLE
release: bump to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -7443,7 +7443,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "clap",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.1"
+version = "1.6.0"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"


### PR DESCRIPTION
Bumps `[workspace.package].version` from 1.5.1 to 1.6.0.

Merging this to `main` triggers the release workflow, which creates the `1.6.0` tag, builds binaries, publishes the GitHub release, and updates the Homebrew formula.

Notable user-facing changes since 1.5.1:
- Upload a local project profile image via `pcl projects create|update --profile-image`, and clear it with `--remove-profile-image` (#112)
- Remember a custom platform URL from `pcl auth login -u <url>` (#110)
- Agentic on-chain assertion deployment (#107)
- `pcl apply`: render assertion changes under unchanged contracts (#113)

Version bump only; CHANGELOG left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)