### PR TITLE
chore(release): bump to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -9182,7 +9182,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -9199,7 +9199,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -9207,7 +9207,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -9248,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"


### PR DESCRIPTION
Bumps PCL from 1.6.0 to 1.7.0. This release adds V2 compatibility warnings for V1 targets and includes the finalized Phoundry and Credible SDK dependency updates plus CI hardening. Merging to `main` triggers the tag, binary build, GitHub release, and Homebrew publication workflow.