### PR TITLE
fix(pcl): remove the default platform URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1021,7 +1021,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1152,6 +1152,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1193,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1211,6 +1238,19 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1290,7 +1330,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1298,10 +1338,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1333,6 +1397,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -2739,7 +2813,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2900,7 +2974,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4531,7 +4605,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4940,7 +5014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7358,7 +7432,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8466,7 +8540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8718,7 +8792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -11572,15 +11646,16 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -11670,7 +11745,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11729,7 +11804,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12534,7 +12609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13217,7 +13292,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13451,7 +13526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14967,7 +15042,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15295,7 +15370,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/dapp-api-client/src/config.rs
+++ b/crates/dapp-api-client/src/config.rs
@@ -56,6 +56,14 @@ impl fmt::Display for Environment {
 
 impl Environment {
     /// Get the base URL for this environment
+    ///
+    /// Note: `pcl` does not use this. It builds its base URL from the platform
+    /// URL resolved for the invocation (see `pcl_core::client::api_base_url`),
+    /// because a compiled-in host pins one network into the binary and
+    /// `dapp.phylax.systems` answers with a 301 — and a redirected POST is
+    /// downgraded to GET by reqwest, silently dropping the request body. These
+    /// constants remain for the crate's standalone examples only; anything
+    /// issuing writes should derive its base URL from a resolved platform.
     pub fn base_url(&self) -> &'static str {
         match self {
             Environment::Development => "http://localhost:3000/api/v1",

--- a/crates/pcl/cli/src/cli.rs
+++ b/crates/pcl/cli/src/cli.rs
@@ -15,7 +15,6 @@ use pcl_core::deploy::DeployArgs;
 #[cfg(feature = "credible")]
 use pcl_core::verify::VerifyArgs;
 use pcl_core::{
-    DEFAULT_PLATFORM_URL,
     api::{
         AccessCommand,
         AccountCommand,
@@ -35,6 +34,7 @@ use pcl_core::{
     auth::AuthCommand,
     config::ConfigArgs,
     download::DownloadArgs,
+    platform::Url,
     surface::{
         ArtifactsArgs,
         DoctorArgs,
@@ -57,12 +57,13 @@ fn version_message() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
     VERSION
         .get_or_init(|| {
+            // No "Default Platform URL" line: there is no compiled-in default
+            // platform to report.
             format!(
-                "{}\nCommit: {}\nBuild Timestamp: {}\nDefault Platform URL: {}",
+                "{}\nCommit: {}\nBuild Timestamp: {}",
                 env!("CARGO_PKG_VERSION"),
                 env!("VERGEN_GIT_SHA"),
                 env!("VERGEN_BUILD_TIMESTAMP"),
-                DEFAULT_PLATFORM_URL,
             )
         })
         .as_str()
@@ -182,6 +183,91 @@ impl Commands {
     pub fn should_force_config_write(&self) -> bool {
         matches!(self, Self::Config(config) if config.should_force_config_write())
             || matches!(self, Self::Auth(auth) if auth.should_force_config_write())
+    }
+
+    /// Whether an explicit `-u`/`--auth-url` should update the remembered
+    /// platform. Only `pcl auth login` moves the user's platform; on every
+    /// other command `-u` is a one-shot override.
+    pub fn should_persist_platform_url(&self) -> bool {
+        matches!(self, Self::Auth(auth) if auth.persists_platform_url())
+    }
+
+    /// Whether this command talks to a platform and therefore needs one
+    /// resolved before dispatch.
+    ///
+    /// Written as an exclusion list so a newly added command resolves a
+    /// platform by default: resolving one that goes unused is harmless, while
+    /// failing to resolve one that is needed is not.
+    pub fn needs_platform_url(&self) -> bool {
+        !self.is_platform_independent()
+    }
+
+    /// Commands that run entirely against local state — the build toolchain,
+    /// on-disk config, or static metadata — and must never prompt for a
+    /// network.
+    fn is_platform_independent(&self) -> bool {
+        // `auth status` reads local config only, and `doctor --offline`
+        // deliberately makes no network calls.
+        #[cfg(feature = "credible")]
+        if matches!(self, Self::Apply(apply) if !apply.needs_platform_url()) {
+            return true;
+        }
+        if matches!(self, Self::Auth(auth) if !auth.needs_platform_url())
+            || matches!(self, Self::Doctor(doctor) if doctor.is_offline())
+            || matches!(self, Self::Api(api) if !api.needs_platform_url())
+        {
+            return true;
+        }
+        match self {
+            #[cfg(feature = "credible")]
+            Self::Test(_) | Self::Verify(_) => true,
+            Self::Build(_)
+            | Self::Config(_)
+            | Self::Whoami(_)
+            | Self::Workflows(_)
+            | Self::Artifacts(_)
+            | Self::Requests(_)
+            | Self::Schema(_)
+            | Self::Llms(_)
+            | Self::Jobs(_)
+            | Self::Completions(_) => true,
+            _ => false,
+        }
+    }
+
+    /// The explicit `-u`/`--api-url`/`--auth-url` (or `PCL_*` env) value for
+    /// this command, when one was given. An explicit value short-circuits
+    /// platform resolution, so no prompt or error is needed.
+    pub fn platform_url_flag(&self) -> Option<Url> {
+        // `auth` resolves its own precedence (PCL_AUTH_URL then PCL_API_URL),
+        // so it returns an owned URL rather than a borrow of a parsed field.
+        if let Self::Auth(auth) = self {
+            return auth.platform_url_flag();
+        }
+        let flag = match self {
+            #[cfg(feature = "credible")]
+            Self::Apply(apply) => apply.api_url.as_ref(),
+            #[cfg(feature = "credible")]
+            Self::Deploy(deploy) => deploy.api_url.as_ref(),
+            Self::Api(api) => api.platform_url_flag(),
+            Self::Download(download) => download.api_url.as_ref(),
+            Self::Doctor(doctor) => doctor.platform_url_flag(),
+            Self::Export(export) => export.platform_url_flag(),
+            Self::Incidents(command) => command.platform_url_flag(),
+            Self::Projects(command) => command.platform_url_flag(),
+            Self::Assertions(command) => command.platform_url_flag(),
+            Self::Search(command) => command.platform_url_flag(),
+            Self::Account(command) => command.platform_url_flag(),
+            Self::Contracts(command) => command.platform_url_flag(),
+            Self::Releases(command) => command.platform_url_flag(),
+            Self::Deployments(command) => command.platform_url_flag(),
+            Self::Access(command) => command.platform_url_flag(),
+            Self::Integrations(command) => command.platform_url_flag(),
+            Self::ProtocolManager(command) => command.platform_url_flag(),
+            Self::Events(command) => command.platform_url_flag(),
+            _ => None,
+        };
+        flag.cloned()
     }
 }
 

--- a/crates/pcl/cli/src/cli.rs
+++ b/crates/pcl/cli/src/cli.rs
@@ -209,13 +209,23 @@ impl Commands {
         // `auth status` reads local config only, and `doctor --offline`
         // deliberately makes no network calls.
         #[cfg(feature = "credible")]
-        if matches!(self, Self::Apply(apply) if !apply.needs_platform_url()) {
+        if matches!(self, Self::Apply(apply) if !apply.needs_platform_url())
+            || matches!(self, Self::Deploy(deploy) if !deploy.needs_platform_url())
+        {
             return true;
         }
         if matches!(self, Self::Auth(auth) if !auth.needs_platform_url())
             || matches!(self, Self::Doctor(doctor) if doctor.is_offline())
             || matches!(self, Self::Api(api) if !api.needs_platform_url())
+            || matches!(self, Self::Export(export) if !export.needs_platform_url())
         {
+            return true;
+        }
+        // `--body-template` on a workflow command prints a static, compiled-in
+        // request schema and returns before any client is built. Those runs are
+        // how an agent discovers a body shape, so they have to work before a
+        // network has been chosen.
+        if self.is_local_workflow_template() {
             return true;
         }
         match self {
@@ -231,6 +241,27 @@ impl Commands {
             | Self::Llms(_)
             | Self::Jobs(_)
             | Self::Completions(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Whether this is a workflow command invoked purely to print its local
+    /// request-body schema.
+    ///
+    /// Listed per command rather than as one blanket rule: only these carry a
+    /// `--body-template` flag, and a command that grows one has to opt in here so
+    /// the platform requirement is a decision rather than an accident.
+    fn is_local_workflow_template(&self) -> bool {
+        match self {
+            Self::Assertions(command) => !command.needs_platform_url(),
+            Self::Account(command) => !command.needs_platform_url(),
+            Self::Contracts(command) => !command.needs_platform_url(),
+            Self::Releases(command) => !command.needs_platform_url(),
+            Self::Deployments(command) => !command.needs_platform_url(),
+            Self::Access(command) => !command.needs_platform_url(),
+            Self::Integrations(command) => !command.needs_platform_url(),
+            Self::ProtocolManager(command) => !command.needs_platform_url(),
+            Self::Projects(command) => !command.needs_platform_url(),
             _ => false,
         }
     }

--- a/crates/pcl/cli/src/main.rs
+++ b/crates/pcl/cli/src/main.rs
@@ -125,28 +125,37 @@ async fn main() -> Result<()> {
             std::process::exit(1);
         }
     };
+    // Snapshot of what is on disk, taken before normalization so that rewriting
+    // a legacy short expiry counts as a change worth persisting.
     let mut original_config = config.clone();
     config.normalize_auth_expiry_from_access_token();
 
     let should_write_after_invalid_config = cli.command.should_write_after_invalid_config();
-    if establish_active_platform(&cli.command, &cli.args, &mut config)?
-        && (read_valid_config || should_write_after_invalid_config)
-    {
-        // Persist a newly chosen platform immediately, before running the
-        // command. The prompt is meant to be one-time, and the choice is the
-        // user's regardless of whether the command then succeeds — deferring
-        // this to the post-command write loses it on any failure and prompts
-        // again on the next run.
-        config.write_to_file(&cli.args)?;
-        // The write below only fires when the file still matches this snapshot,
-        // so it has to reflect what was just written.
-        original_config = config.clone();
-    }
-
-    let baseline_config = config.clone();
-
     let should_force_config_write = cli.command.should_force_config_write();
+    // Everything that can fail lives inside this block so a failure becomes one
+    // structured envelope. A config write that escaped it would print a
+    // color-eyre diagnostic instead, breaking the single-envelope contract that
+    // `--json` callers parse.
     let result = async {
+        let platform_recorded = establish_active_platform(&cli.command, &cli.args, &mut config)?;
+        // Persist a newly chosen platform before running the command. The
+        // prompt is meant to be one-time, and the choice is the user's
+        // regardless of whether the command then succeeds — deferring this to
+        // the post-command write loses it on any failure and prompts again on
+        // the next run.
+        //
+        // Only when the file on disk parsed. Writing now would replace an
+        // unreadable config with a default one before the repair command has
+        // produced anything, so a cancelled or failed repair would destroy
+        // recoverable credentials; that case is left to the post-command write.
+        if platform_recorded && read_valid_config {
+            persist_selected_platform(&cli.args, &mut config)?;
+            // The write below only fires when the file still matches this
+            // snapshot, so it has to reflect what was just written.
+            original_config = config.clone();
+        }
+
+        let baseline_config = config.clone();
         run_command(cli.command, &cli.args, &mut config, cli.args.json_output()).await?;
         let command_changed_config = config != baseline_config;
         let passive_config_changed = baseline_config != original_config;
@@ -159,6 +168,12 @@ async fn main() -> Result<()> {
             if read_valid_config && !force_config_write {
                 config.write_to_file_if_unchanged(&cli.args, &original_config)?;
             } else {
+                if !read_valid_config {
+                    // About to replace a file this run could not parse. Keep the
+                    // original bytes: they may still hold credentials or RPC
+                    // settings that can be recovered by hand.
+                    CliConfig::back_up_unreadable(&cli.args)?;
+                }
                 config.write_to_file(&cli.args)?;
             }
         }
@@ -224,6 +239,31 @@ async fn run_command(
         Commands::Verify(verify_cmd) => verify_cmd.run(cli_args)?,
         Commands::Download(download_cmd) => download_cmd.run(cli_args, config).await?,
     }
+    Ok(())
+}
+
+/// Writes a freshly chosen platform without clobbering a concurrent update.
+///
+/// The in-memory config was read before the selector prompted, and a prompt sits
+/// open for as long as the user takes to answer. Another `pcl` can rotate the
+/// refresh token or change RPC settings in that window, and writing this
+/// process's snapshot over the result would discard them — losing the only valid
+/// refresh token. So the platform is merged into whatever is on disk *now*, and
+/// this process adopts that state for the rest of the run.
+fn persist_selected_platform(cli_args: &CliArgs, config: &mut CliConfig) -> Result<()> {
+    let Ok(mut current) = CliConfig::read_from_file(cli_args) else {
+        // Unreadable only if it changed under us since startup, where the
+        // caller already parsed it. Nothing to merge, so record the choice.
+        config.write_to_file(cli_args)?;
+        return Ok(());
+    };
+    if current == *config {
+        return Ok(());
+    }
+    current.normalize_auth_expiry_from_access_token();
+    current.platform_url.clone_from(&config.platform_url);
+    current.write_to_file(cli_args)?;
+    *config = current;
     Ok(())
 }
 
@@ -1368,6 +1408,68 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
     use pcl_core::api::envelope_output_string;
+
+    /// Recording a selected platform must not roll back a concurrent update.
+    ///
+    /// The interactive selector can sit open indefinitely, and another `pcl` may
+    /// rotate the refresh token while it does. Writing this process's pre-prompt
+    /// snapshot would discard the rotation and leave a refresh token the
+    /// platform has already invalidated.
+    #[test]
+    fn persisting_a_selected_platform_keeps_a_concurrently_rotated_token() {
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let cli_args = CliArgs {
+            config_dir: Some(config_dir.path().to_path_buf()),
+            ..CliArgs::default()
+        };
+
+        // What this process read before prompting.
+        let stale = CliConfig {
+            auth: Some(pcl_core::config::UserAuth {
+                access_token: "old-access".to_string(),
+                refresh_token: "old-refresh".to_string(),
+                expires_at: chrono::DateTime::from_timestamp(1_600_000_000, 0).expect("timestamp"),
+                refresh_expires_at: None,
+                user_id: None,
+                wallet_address: None,
+                email: None,
+                issuer_platform_url: Some("https://linea.phylax.systems".to_string()),
+            }),
+            ..CliConfig::default()
+        };
+
+        // What another process wrote while the prompt was open.
+        let mut rotated = stale.clone();
+        if let Some(auth) = &mut rotated.auth {
+            auth.access_token = "rotated-access".to_string();
+            auth.refresh_token = "rotated-refresh".to_string();
+        }
+        rotated
+            .write_to_file(&cli_args)
+            .expect("another process writes the rotated pair");
+
+        // The selection this process made.
+        let mut config = stale.clone();
+        config.platform_url = Some("https://ethereum.phylax.systems".to_string());
+        persist_selected_platform(&cli_args, &mut config).expect("persist the selection");
+
+        let on_disk = CliConfig::read_from_file(&cli_args).expect("read merged config");
+        let auth = on_disk.auth.as_ref().expect("credentials survive");
+        assert_eq!(
+            auth.refresh_token, "rotated-refresh",
+            "the concurrently rotated refresh token must survive"
+        );
+        assert_eq!(auth.access_token, "rotated-access");
+        assert_eq!(
+            on_disk.platform_url.as_deref(),
+            Some("https://ethereum.phylax.systems"),
+            "the selection still has to be recorded"
+        );
+        assert_eq!(
+            config, on_disk,
+            "this process adopts the merged state for the rest of the run"
+        );
+    }
 
     #[test]
     fn detects_output_mode_before_successful_parse() {

--- a/crates/pcl/cli/src/main.rs
+++ b/crates/pcl/cli/src/main.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<()> {
         // produced anything, so a cancelled or failed repair would destroy
         // recoverable credentials; that case is left to the post-command write.
         if platform_recorded && read_valid_config {
-            persist_selected_platform(&cli.args, &mut config)?;
+            config.merge_selected_platform(&cli.args).await?;
             // The write below only fires when the file still matches this
             // snapshot, so it has to reflect what was just written.
             original_config = config.clone();
@@ -239,31 +239,6 @@ async fn run_command(
         Commands::Verify(verify_cmd) => verify_cmd.run(cli_args)?,
         Commands::Download(download_cmd) => download_cmd.run(cli_args, config).await?,
     }
-    Ok(())
-}
-
-/// Writes a freshly chosen platform without clobbering a concurrent update.
-///
-/// The in-memory config was read before the selector prompted, and a prompt sits
-/// open for as long as the user takes to answer. Another `pcl` can rotate the
-/// refresh token or change RPC settings in that window, and writing this
-/// process's snapshot over the result would discard them — losing the only valid
-/// refresh token. So the platform is merged into whatever is on disk *now*, and
-/// this process adopts that state for the rest of the run.
-fn persist_selected_platform(cli_args: &CliArgs, config: &mut CliConfig) -> Result<()> {
-    let Ok(mut current) = CliConfig::read_from_file(cli_args) else {
-        // Unreadable only if it changed under us since startup, where the
-        // caller already parsed it. Nothing to merge, so record the choice.
-        config.write_to_file(cli_args)?;
-        return Ok(());
-    };
-    if current == *config {
-        return Ok(());
-    }
-    current.normalize_auth_expiry_from_access_token();
-    current.platform_url.clone_from(&config.platform_url);
-    current.write_to_file(cli_args)?;
-    *config = current;
     Ok(())
 }
 
@@ -1203,6 +1178,7 @@ fn config_error_code(err: &ConfigError) -> &'static str {
         ConfigError::JsonError(_) => "config.json_failed",
         ConfigError::NotAuthenticated => "config.not_authenticated",
         ConfigError::InvalidValue(_) => "config.invalid_value",
+        ConfigError::LockTimeout => "config.lock_timeout",
     }
 }
 
@@ -1408,68 +1384,6 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
     use pcl_core::api::envelope_output_string;
-
-    /// Recording a selected platform must not roll back a concurrent update.
-    ///
-    /// The interactive selector can sit open indefinitely, and another `pcl` may
-    /// rotate the refresh token while it does. Writing this process's pre-prompt
-    /// snapshot would discard the rotation and leave a refresh token the
-    /// platform has already invalidated.
-    #[test]
-    fn persisting_a_selected_platform_keeps_a_concurrently_rotated_token() {
-        let config_dir = tempfile::tempdir().expect("temp config dir");
-        let cli_args = CliArgs {
-            config_dir: Some(config_dir.path().to_path_buf()),
-            ..CliArgs::default()
-        };
-
-        // What this process read before prompting.
-        let stale = CliConfig {
-            auth: Some(pcl_core::config::UserAuth {
-                access_token: "old-access".to_string(),
-                refresh_token: "old-refresh".to_string(),
-                expires_at: chrono::DateTime::from_timestamp(1_600_000_000, 0).expect("timestamp"),
-                refresh_expires_at: None,
-                user_id: None,
-                wallet_address: None,
-                email: None,
-                issuer_platform_url: Some("https://linea.phylax.systems".to_string()),
-            }),
-            ..CliConfig::default()
-        };
-
-        // What another process wrote while the prompt was open.
-        let mut rotated = stale.clone();
-        if let Some(auth) = &mut rotated.auth {
-            auth.access_token = "rotated-access".to_string();
-            auth.refresh_token = "rotated-refresh".to_string();
-        }
-        rotated
-            .write_to_file(&cli_args)
-            .expect("another process writes the rotated pair");
-
-        // The selection this process made.
-        let mut config = stale.clone();
-        config.platform_url = Some("https://ethereum.phylax.systems".to_string());
-        persist_selected_platform(&cli_args, &mut config).expect("persist the selection");
-
-        let on_disk = CliConfig::read_from_file(&cli_args).expect("read merged config");
-        let auth = on_disk.auth.as_ref().expect("credentials survive");
-        assert_eq!(
-            auth.refresh_token, "rotated-refresh",
-            "the concurrently rotated refresh token must survive"
-        );
-        assert_eq!(auth.access_token, "rotated-access");
-        assert_eq!(
-            on_disk.platform_url.as_deref(),
-            Some("https://ethereum.phylax.systems"),
-            "the selection still has to be recorded"
-        );
-        assert_eq!(
-            config, on_disk,
-            "this process adopts the merged state for the rest of the run"
-        );
-    }
 
     #[test]
     fn detects_output_mode_before_successful_parse() {

--- a/crates/pcl/cli/src/main.rs
+++ b/crates/pcl/cli/src/main.rs
@@ -32,8 +32,16 @@ use pcl_core::{
         AuthError,
         ConfigError,
         DeployError,
+        PlatformError,
     },
     output::command_for_mode,
+    platform::{
+        Interaction,
+        Url,
+        describe_platform,
+        resolve_for_invocation,
+        set_active_platform,
+    },
     surface::ProductSurfaceError,
 };
 #[cfg(feature = "credible")]
@@ -117,11 +125,26 @@ async fn main() -> Result<()> {
             std::process::exit(1);
         }
     };
-    let original_config = config.clone();
+    let mut original_config = config.clone();
     config.normalize_auth_expiry_from_access_token();
-    let baseline_config = config.clone();
 
     let should_write_after_invalid_config = cli.command.should_write_after_invalid_config();
+    if establish_active_platform(&cli.command, &cli.args, &mut config)?
+        && (read_valid_config || should_write_after_invalid_config)
+    {
+        // Persist a newly chosen platform immediately, before running the
+        // command. The prompt is meant to be one-time, and the choice is the
+        // user's regardless of whether the command then succeeds — deferring
+        // this to the post-command write loses it on any failure and prompts
+        // again on the next run.
+        config.write_to_file(&cli.args)?;
+        // The write below only fires when the file still matches this snapshot,
+        // so it has to reflect what was just written.
+        original_config = config.clone();
+    }
+
+    let baseline_config = config.clone();
+
     let should_force_config_write = cli.command.should_force_config_write();
     let result = async {
         run_command(cli.command, &cli.args, &mut config, cli.args.json_output()).await?;
@@ -204,6 +227,90 @@ async fn run_command(
     Ok(())
 }
 
+/// Resolves the platform for this invocation and records it so every argument
+/// accessor sees the same one.
+///
+/// Runs before dispatch, while `config` is still writable: a fresh selection is
+/// recorded here and persisted by the normal config-write path, which keeps the
+/// prompt one-time. Resolving once also gives every command a single place to
+/// announce its platform.
+///
+/// Exits with a structured envelope when nothing resolves — a non-interactive
+/// run with no platform cannot proceed, and must never hang on a prompt.
+///
+/// Returns whether a platform was recorded in `config` and therefore needs
+/// persisting.
+fn establish_active_platform(
+    command: &Commands,
+    cli_args: &CliArgs,
+    config: &mut CliConfig,
+) -> Result<bool> {
+    // A command that needs no platform still reports the one it would use when
+    // that is already known — `pcl doctor --offline` should name the platform it
+    // is diagnosing — but it must never prompt, and must not fail when nothing
+    // is configured.
+    let needs_platform = command.needs_platform_url();
+    let interaction = if needs_platform {
+        Interaction::detect(cli_args.json_output())
+    } else {
+        Interaction::Forbidden
+    };
+    let remembered_before = config.platform_url.clone();
+    match resolve_for_invocation(
+        command.platform_url_flag().as_ref(),
+        config,
+        command.should_persist_platform_url(),
+        interaction,
+    ) {
+        Ok(platform_url) => {
+            // Only a command that actually talks to the platform announces it:
+            // the line exists so a wrong network is noticed before it is acted
+            // on. Local-only commands that surface the platform do so in their
+            // own output, and must not prepend anything to an error.
+            if needs_platform {
+                announce_platform(&platform_url, cli_args.output_mode());
+            }
+            set_active_platform(platform_url);
+            Ok(config.platform_url != remembered_before)
+        }
+        // Nothing to report, and nothing this command needs.
+        Err(_) if !needs_platform => Ok(false),
+        Err(err) => {
+            let envelope = with_envelope_metadata(platform_error_envelope(&err));
+            eprint!("{}", envelope_output_string(&envelope, false)?);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Announces the platform every command is about to talk to, so a wrong
+/// network is caught by eye rather than by a prompt.
+///
+/// Goes to stderr: stdout carries command data, and a machine run must stay
+/// parseable.
+fn announce_platform(platform_url: &Url, output_mode: OutputMode) {
+    if output_mode == OutputMode::Human {
+        eprintln!("Using {}", describe_platform(platform_url));
+    }
+}
+
+fn platform_error_envelope(err: &PlatformError) -> Value {
+    let (code, next_actions): (&str, &[&str]) = match err {
+        PlatformError::NoPlatformResolved { .. } => {
+            (
+                "platform.not_selected",
+                &[
+                    "pcl auth login (choose a network interactively)",
+                    "pcl <command> -u https://linea.phylax.systems",
+                    "PCL_API_URL=https://linea.phylax.systems pcl <command>",
+                ],
+            )
+        }
+        PlatformError::SelectionFailed(_) => ("platform.selection_failed", &["pcl auth login"]),
+    };
+    simple_error_value(code, &err.to_string(), true, next_actions)
+}
+
 fn ensure_human_pass_through(
     cli_args: &CliArgs,
     command: &'static str,
@@ -231,6 +338,9 @@ fn error_envelope(err: &Report) -> Value {
     }
     if let Some(config_error) = err.downcast_ref::<ConfigError>() {
         return with_envelope_metadata(config_error_envelope(config_error));
+    }
+    if let Some(platform_error) = err.downcast_ref::<PlatformError>() {
+        return with_envelope_metadata(platform_error_envelope(platform_error));
     }
     if let Some(download_error) = err.downcast_ref::<DownloadError>() {
         return with_envelope_metadata(download_error_envelope(download_error));
@@ -341,6 +451,9 @@ fn apply_error_envelope(err: &ApplyError) -> Value {
             )
         }
         ApplyError::ApplyCancelled => ("apply.cancelled", err.to_string(), &["pcl apply --help"]),
+        ApplyError::Platform(platform_error) => {
+            return platform_error_envelope(platform_error);
+        }
         _ => {
             (
                 "apply.failed",

--- a/crates/pcl/cli/tests/auth_output.rs
+++ b/crates/pcl/cli/tests/auth_output.rs
@@ -18,19 +18,25 @@ fn write_valid_auth_config(config_dir: &std::path::Path) {
 /// Like [`write_valid_auth_config`], but records the platform that issued the
 /// credentials, so commands aimed at that URL pass the platform-boundary
 /// check.
+///
+/// `issuer_platform_url` under `[auth]` is what the boundary check reads; the
+/// top-level `platform_url` only says which platform is remembered. A fixture
+/// for "logged in to this platform" has to set both, because that is what a
+/// real login writes.
 fn write_valid_auth_config_for_platform(config_dir: &std::path::Path, platform_url: &str) {
+    let platform_url = platform_url.trim_end_matches('/');
     fs::write(
         config_dir.join("config.toml"),
         format!(
-            r#"platform_url = "{}"
+            r#"platform_url = "{platform_url}"
 
 [auth]
 access_token = "test-token"
 refresh_token = "refresh-token"
 expires_at = 4102444800
 email = "agent@example.com"
-"#,
-            platform_url.trim_end_matches('/')
+issuer_platform_url = "{platform_url}"
+"#
         ),
     )
     .expect("write test config");
@@ -53,6 +59,7 @@ fn write_expired_refreshable_auth_config_for_platform(
     config_dir: &std::path::Path,
     platform_url: &str,
 ) {
+    let platform_url = platform_url.trim_end_matches('/');
     fs::write(
         config_dir.join("config.toml"),
         format!(
@@ -63,6 +70,7 @@ access_token = "expired-token"
 refresh_token = "refresh-token"
 expires_at = 1
 email = "agent@example.com"
+issuer_platform_url = "{platform_url}"
 "#
         ),
     )
@@ -672,6 +680,149 @@ fn auth_login_force_starts_fresh_flow_even_with_existing_auth() {
     auth_status.assert();
 }
 
+/// The platform that issued the credentials a boundary test starts from.
+///
+/// `.invalid` never resolves, so a request that escapes to the issuing platform
+/// fails loudly instead of silently succeeding against something real.
+const OTHER_PLATFORM_URL: &str = "https://platform-a.invalid";
+
+#[test]
+fn login_against_another_platform_does_not_short_circuit_on_the_old_token() {
+    // Startup persists an explicit `--auth-url` as the remembered platform
+    // before the login runs. If the boundary check read that field it would be
+    // comparing the target against itself, find no switch, and short-circuit —
+    // leaving the old platform's token bound to the new platform for every
+    // later command.
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config_for_platform(temp_dir.path(), OTHER_PLATFORM_URL);
+    let mut server = mockito::Server::new();
+    let auth_code = server
+        .mock("GET", "/api/v1/cli/auth/code")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"code":"123456","sessionId":"550e8400-e29b-41d4-a716-446655440000","deviceSecret":"test_secret","expiresAt":"2099-12-31T00:00:00Z"}"#,
+        )
+        .expect(1)
+        .create();
+    let auth_status = server
+        .mock("GET", "/api/v1/cli/auth/status")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded(
+                "session_id".into(),
+                "550e8400-e29b-41d4-a716-446655440000".into(),
+            ),
+            mockito::Matcher::UrlEncoded("device_secret".into(), "test_secret".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"verified":true,"user_id":"550e8400-e29b-41d4-a716-446655440000","token":"token-from-platform-b","refresh_token":"refresh-from-platform-b","email":"agent@example.com"}"#,
+        )
+        .expect(1)
+        .create();
+    // Created last: mockito matches in creation order, so this only catches
+    // requests the login flow above did not already claim.
+    let never_authenticated = server
+        .mock("GET", mockito::Matcher::Any)
+        .match_header("authorization", "Bearer test-token")
+        .with_status(200)
+        .expect(0)
+        .create();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .env("PCL_AUTH_NO_BROWSER", "1")
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "--json",
+            "auth",
+            "--auth-url",
+            &server.url(),
+            "login",
+        ])
+        .output()
+        .expect("run pcl auth login against another platform");
+
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // A real device-auth flow ran rather than "already authenticated".
+    auth_code.assert();
+    auth_status.assert();
+    never_authenticated.assert();
+
+    let config = fs::read_to_string(temp_dir.path().join("config.toml")).expect("read config");
+    assert!(
+        config.contains("access_token = \"token-from-platform-b\""),
+        "the new platform's token must replace the old one: {config}"
+    );
+    assert!(
+        !config.contains("test-token"),
+        "the old platform's token must not survive the switch: {config}"
+    );
+    assert!(
+        config.contains(&format!(
+            "issuer_platform_url = \"{}\"",
+            server.url().trim_end_matches('/')
+        )),
+        "the stored credentials must record the platform that issued them: {config}"
+    );
+}
+
+#[test]
+fn credentials_without_a_recorded_issuer_are_refused_against_a_remembered_platform() {
+    // The upgrade path, and the state a fresh interactive selection leaves
+    // behind: credentials from a release that recorded no issuer, plus a
+    // remembered platform written by resolution rather than by a login. The
+    // promised one-time re-login only happens if the boundary check refuses to
+    // read that remembered value as provenance.
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    let mut server = mockito::Server::new();
+    let never_requested = server
+        .mock("GET", mockito::Matcher::Any)
+        .with_status(200)
+        .expect(0)
+        .create();
+    fs::write(
+        temp_dir.path().join("config.toml"),
+        format!(
+            r#"platform_url = "{}"
+
+[auth]
+access_token = "legacy-token"
+refresh_token = "legacy-refresh"
+expires_at = 4102444800
+email = "agent@example.com"
+"#,
+            server.url().trim_end_matches('/')
+        ),
+    )
+    .expect("write legacy config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "--json",
+            "projects",
+            "mine",
+        ])
+        .output()
+        .expect("run pcl projects mine");
+
+    assert!(!output.status.success(), "the command must be refused");
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    let envelope: serde_json::Value =
+        serde_json::from_str(if stdout.is_empty() { &stderr } else { &stdout })
+            .expect("json envelope");
+    assert_eq!(envelope["error"]["code"], "auth.platform_mismatch");
+    never_requested.assert();
+}
+
 #[test]
 fn auth_poll_json_verified_stores_auth_and_returns_terminal_envelope() {
     let temp_dir = tempfile::tempdir().expect("create temp config dir");
@@ -876,6 +1027,129 @@ fn login_records_its_platform_even_when_the_login_itself_fails() {
     assert!(
         config.contains(r#"platform_url = "http://127.0.0.1:9""#),
         "the resolved platform must survive a failing command: {config}"
+    );
+}
+
+/// A failure while persisting the resolved platform still has to arrive as the
+/// one JSON envelope a machine caller parses. It used to escape the structured
+/// error boundary and print a color-eyre diagnostic instead.
+#[test]
+fn platform_write_failure_under_json_emits_a_single_error_envelope() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    write_valid_auth_config_for_platform(temp_dir.path(), OTHER_PLATFORM_URL);
+    // Read and execute but not write: resolution succeeds, then persisting the
+    // explicitly requested platform fails.
+    let mut permissions = fs::metadata(temp_dir.path())
+        .expect("read temp dir metadata")
+        .permissions();
+    permissions.set_readonly(true);
+    fs::set_permissions(temp_dir.path(), permissions).expect("make config dir read-only");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .env("PCL_AUTH_NO_BROWSER", "1")
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "--json",
+            "auth",
+            "--auth-url",
+            "http://127.0.0.1:9",
+            "login",
+        ])
+        .output()
+        .expect("run pcl auth login");
+
+    // Restore write access so the temp dir can be cleaned up.
+    let mut permissions = fs::metadata(temp_dir.path())
+        .expect("read temp dir metadata")
+        .permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    permissions.set_readonly(false);
+    fs::set_permissions(temp_dir.path(), permissions).expect("restore config dir permissions");
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        !stderr.contains("Location:"),
+        "a color-eyre diagnostic escaped the error boundary: {stderr}"
+    );
+    let rendered = if stdout.is_empty() { &stderr } else { &stdout };
+    let envelope: serde_json::Value =
+        serde_json::from_str(rendered.trim()).expect("a single json envelope");
+    assert_eq!(envelope["status"], "error");
+    assert_eq!(envelope["schema_version"], "pcl.envelope.v1");
+}
+
+/// A command allowed to repair an unreadable config must not destroy it before
+/// it has actually produced its replacement: a cancelled or failed repair would
+/// take recoverable credentials and RPC settings with it.
+#[test]
+fn a_failed_repair_preserves_the_unreadable_config() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    let config_path = temp_dir.path().join("config.toml");
+    let damaged =
+        "platform_url = \"http://127.0.0.1:9\"\n\n[auth]\nexpires_at = \"2099-12-31T00:00:00Z\"\n";
+    fs::write(&config_path, damaged).expect("write damaged config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .env("PCL_AUTH_NO_BROWSER", "1")
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "--json",
+            "auth",
+            "--auth-url",
+            "http://127.0.0.1:9",
+            "login",
+        ])
+        .output()
+        .expect("run pcl auth login");
+
+    assert!(
+        !output.status.success(),
+        "login against a dead host should fail"
+    );
+    let after = fs::read_to_string(&config_path).expect("read config");
+    assert_eq!(
+        after, damaged,
+        "a failed repair must leave the original file intact"
+    );
+}
+
+/// A repair that does replace an unreadable config keeps the original bytes
+/// alongside it, so credentials or RPC settings inside remain recoverable.
+#[test]
+fn repairing_an_unreadable_config_preserves_the_original_bytes() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    let config_path = temp_dir.path().join("config.toml");
+    let damaged = "platform_url = \"https://linea.phylax.systems\"\n\n[auth]\naccess_token = \"recoverable\"\nexpires_at = \"2099-12-31T00:00:00Z\"\n";
+    fs::write(&config_path, damaged).expect("write damaged config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "--json",
+            "config",
+            "delete",
+        ])
+        .output()
+        .expect("run pcl config delete");
+
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let backup = fs::read_to_string(temp_dir.path().join("config.toml.invalid"))
+        .expect("the unreadable config is preserved alongside its replacement");
+    assert_eq!(backup, damaged);
+    assert!(
+        !fs::read_to_string(&config_path)
+            .expect("read replacement")
+            .contains("recoverable"),
+        "the replacement config must not carry the unparsed credentials forward"
     );
 }
 

--- a/crates/pcl/cli/tests/auth_output.rs
+++ b/crates/pcl/cli/tests/auth_output.rs
@@ -3,17 +3,16 @@ use std::{
     process::Command,
 };
 
+/// The platform recorded by fixtures that just need "a logged-in user".
+///
+/// Every config written after a login records its platform explicitly — there
+/// is no production default whose absence stands in for one. A config with
+/// credentials but no `platform_url` is a pre-upgrade artifact, and is covered
+/// separately by the platform-boundary unit tests.
+const TEST_PLATFORM_URL: &str = "https://linea.phylax.systems";
+
 fn write_valid_auth_config(config_dir: &std::path::Path) {
-    fs::write(
-        config_dir.join("config.toml"),
-        r#"[auth]
-access_token = "test-token"
-refresh_token = "refresh-token"
-expires_at = 4102444800
-email = "agent@example.com"
-"#,
-    )
-    .expect("write test config");
+    write_valid_auth_config_for_platform(config_dir, TEST_PLATFORM_URL);
 }
 
 /// Like [`write_valid_auth_config`], but records the platform that issued the
@@ -71,16 +70,7 @@ email = "agent@example.com"
 }
 
 fn write_expired_refreshable_auth_config(config_dir: &std::path::Path) {
-    fs::write(
-        config_dir.join("config.toml"),
-        r#"[auth]
-access_token = "expired-token"
-refresh_token = "refresh-token"
-expires_at = 1
-email = "agent@example.com"
-"#,
-    )
-    .expect("write expired test config");
+    write_expired_refreshable_auth_config_for_platform(config_dir, TEST_PLATFORM_URL);
 }
 
 #[test]
@@ -853,6 +843,40 @@ fn auth_logout_json_clears_local_config_after_remote_logout() {
     let config = fs::read_to_string(temp_dir.path().join("config.toml")).expect("read config");
     assert!(!config.contains("[auth]"));
     logout.assert();
+}
+
+/// The network prompt is meant to be one-time, so the chosen platform has to be
+/// recorded before the command runs. Persisting it only after a successful
+/// command loses the choice on any failure and prompts again on the next run.
+#[test]
+fn login_records_its_platform_even_when_the_login_itself_fails() {
+    let temp_dir = tempfile::tempdir().expect("create temp config dir");
+    let config_path = temp_dir.path().join("config.toml");
+
+    // Port 9 (discard) refuses the device-code request, so resolution succeeds
+    // and the command then fails.
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .args([
+            "--config-dir",
+            temp_dir.path().to_str().expect("utf-8 temp path"),
+            "auth",
+            "--auth-url",
+            "http://127.0.0.1:9",
+            "login",
+        ])
+        .output()
+        .expect("run pcl auth login");
+
+    assert!(
+        !output.status.success(),
+        "login against a dead host should fail: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let config = fs::read_to_string(&config_path).expect("config written despite the failure");
+    assert!(
+        config.contains(r#"platform_url = "http://127.0.0.1:9""#),
+        "the resolved platform must survive a failing command: {config}"
+    );
 }
 
 #[test]

--- a/crates/pcl/cli/tests/deploy_cli.rs
+++ b/crates/pcl/cli/tests/deploy_cli.rs
@@ -78,3 +78,35 @@ fn deploy_delegates_wrapped_apply_errors_to_their_envelope() {
         "{envelope}"
     );
 }
+
+/// `--dry-run` builds and verifies locally and returns before any client is
+/// built, so planning a deploy must not require choosing a network — and must
+/// not prompt for one, since the flag promises to change nothing.
+///
+/// Run with no `--api-url` and an empty config dir on purpose: the failure has to
+/// be the local project error, not `platform.not_selected`.
+#[test]
+fn deploy_dry_run_needs_no_platform() {
+    let temp_dir = tempfile::tempdir().expect("temp config dir");
+    let missing_root = temp_dir.path().join("does-not-exist");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .arg("--config-dir")
+        .arg(temp_dir.path())
+        .args([
+            "--json",
+            "deploy",
+            "--dry-run",
+            "--root",
+            missing_root.to_str().expect("utf-8"),
+        ])
+        .output()
+        .expect("run pcl deploy --dry-run");
+
+    let envelope = error_envelope(&output);
+    assert_ne!(
+        envelope["error"]["code"], "platform.not_selected",
+        "a local dry run must not require a platform: {envelope}"
+    );
+    assert_eq!(envelope["error"]["code"], "apply.failed", "{envelope}");
+}

--- a/crates/pcl/cli/tests/deploy_cli.rs
+++ b/crates/pcl/cli/tests/deploy_cli.rs
@@ -6,12 +6,19 @@
 
 use std::process::Command;
 
+/// Passed explicitly because there is no default platform: without `-u` these
+/// runs would fail on platform resolution before reaching the deploy error
+/// under test.
+const TEST_PLATFORM_URL: &str = "https://linea.phylax.systems";
+
 fn run_deploy(config_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_pcl"))
         .arg("--config-dir")
         .arg(config_dir)
         .arg("--json")
         .arg("deploy")
+        .arg("--api-url")
+        .arg(TEST_PLATFORM_URL)
         .args(args)
         .output()
         .expect("run pcl deploy")

--- a/crates/pcl/cli/tests/parse_output.rs
+++ b/crates/pcl/cli/tests/parse_output.rs
@@ -39,25 +39,6 @@ fn run_pcl(args: &[&str]) -> PclOutput {
     }
 }
 
-/// Like [`run_pcl`], but names a platform. Workflow commands resolve a platform
-/// before dispatch and there is no default, so a run with an empty config dir
-/// would otherwise stop at platform resolution.
-fn run_pcl_with_platform(args: &[&str]) -> PclOutput {
-    let config_dir = tempfile::tempdir().expect("temp config dir");
-    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
-        .arg("--config-dir")
-        .arg(config_dir.path())
-        .env("PCL_API_URL", "https://linea.phylax.systems")
-        .args(args)
-        .output()
-        .expect("run pcl");
-    PclOutput {
-        success: output.status.success(),
-        stdout: String::from_utf8(output.stdout).expect("utf-8 stdout"),
-        stderr: String::from_utf8(output.stderr).expect("utf-8 stderr"),
-    }
-}
-
 fn assert_json_error(output: &PclOutput, code: &str) {
     output.assert_failure();
     assert!(output.stdout.is_empty());
@@ -190,6 +171,10 @@ fn machine_help_requests_stay_structured() {
     assert_eq!(envelope["schema_version"], "pcl.envelope.v1");
 }
 
+/// `--body-template` prints a static, compiled-in schema. Run with an *empty*
+/// config dir and no `PCL_API_URL` on purpose: these commands are how an agent
+/// discovers a request body shape, so needing a platform first would make them
+/// unusable on a clean install.
 #[test]
 fn new_workflow_subcommands_parse_and_emit_structured_templates() {
     for args in [
@@ -204,10 +189,15 @@ fn new_workflow_subcommands_parse_and_emit_structured_templates() {
         ["--json", "access", "invite", "project-1", "--body-template"].as_slice(),
         ["--json", "releases", "deploy", "--body-template"].as_slice(),
         ["--json", "access", "invite", "--body-template"].as_slice(),
+        ["--json", "contracts", "--assign-project", "--body-template"].as_slice(),
+        ["--json", "protocol-manager", "--set", "--body-template"].as_slice(),
+        ["--json", "deployments", "--confirm", "--body-template"].as_slice(),
+        ["--json", "projects", "create", "--body-template"].as_slice(),
     ] {
-        let output = run_pcl_with_platform(args);
+        let output = run_pcl(args);
 
         output.assert_success();
+        assert!(output.stderr.is_empty(), "{}", output.stderr);
         let envelope: serde_json::Value =
             serde_json::from_str(&output.stdout).expect("json envelope");
         assert_eq!(envelope["status"], "ok", "{envelope}");
@@ -223,6 +213,26 @@ fn new_workflow_subcommands_parse_and_emit_structured_templates() {
             "{envelope}"
         );
     }
+}
+
+/// `export incidents --dry-run` prints a local plan and fetches nothing, so it
+/// must work on a clean non-interactive install. It also must not invent an
+/// `--api-url` for the resume command it prints: with no platform chosen, the
+/// eventual execution resolves one the same way any other command would.
+#[test]
+fn incident_export_dry_run_needs_no_platform() {
+    let output = run_pcl(&["--json", "export", "incidents", "--dry-run"]);
+
+    output.assert_success();
+    let envelope: serde_json::Value = serde_json::from_str(&output.stdout).expect("json envelope");
+    assert_eq!(envelope["status"], "ok", "{envelope}");
+    let resume = envelope["data"]["resume_command"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        !resume.contains("--api-url"),
+        "the resume command must not pin a platform that was never chosen: {resume}"
+    );
 }
 
 #[test]

--- a/crates/pcl/cli/tests/parse_output.rs
+++ b/crates/pcl/cli/tests/parse_output.rs
@@ -171,29 +171,103 @@ fn machine_help_requests_stay_structured() {
     assert_eq!(envelope["schema_version"], "pcl.envelope.v1");
 }
 
+/// Every `--body-template` invocation the CLI accepts, including the ones whose
+/// flag arrives through a flattened or nested args struct — those are the easy
+/// ones to record as always needing a platform, because the outer subcommand
+/// variant carries no `body_template` field of its own.
+const LOCAL_TEMPLATE_INVOCATIONS: &[&[&str]] = &[
+    &["--json", "assertions", "--body-template"],
+    &["--json", "account", "--body-template"],
+    &["--json", "contracts", "--assign-project", "--body-template"],
+    &["--json", "deployments", "--confirm", "--body-template"],
+    &["--json", "integrations", "--body-template"],
+    &["--json", "protocol-manager", "--set", "--body-template"],
+    &["--json", "projects", "create", "--body-template"],
+    &[
+        "--json",
+        "projects",
+        "update",
+        "project-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "releases",
+        "create",
+        "project-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "releases",
+        "preview",
+        "project-1",
+        "--body-template",
+    ],
+    &["--json", "releases", "deploy", "--body-template"],
+    &[
+        "--json",
+        "releases",
+        "remove",
+        "project-1",
+        "release-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "releases",
+        "retry-check",
+        "project-1",
+        "release-1",
+        "check-1",
+        "--body-template",
+    ],
+    &["--json", "access", "accept", "token-1", "--body-template"],
+    &["--json", "access", "invite", "--body-template"],
+    &["--json", "access", "invite", "project-1", "--body-template"],
+    &[
+        "--json",
+        "access",
+        "resend",
+        "project-1",
+        "invitation-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "access",
+        "revoke",
+        "project-1",
+        "invitation-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "access",
+        "role",
+        "update",
+        "project-1",
+        "user-1",
+        "--body-template",
+    ],
+    &[
+        "--json",
+        "access",
+        "member",
+        "remove",
+        "project-1",
+        "user-1",
+        "--body-template",
+    ],
+];
+
 /// `--body-template` prints a static, compiled-in schema. Run with an *empty*
 /// config dir and no `PCL_API_URL` on purpose: these commands are how an agent
 /// discovers a request body shape, so needing a platform first would make them
 /// unusable on a clean install.
 #[test]
 fn new_workflow_subcommands_parse_and_emit_structured_templates() {
-    for args in [
-        [
-            "--json",
-            "releases",
-            "preview",
-            "project-1",
-            "--body-template",
-        ]
-        .as_slice(),
-        ["--json", "access", "invite", "project-1", "--body-template"].as_slice(),
-        ["--json", "releases", "deploy", "--body-template"].as_slice(),
-        ["--json", "access", "invite", "--body-template"].as_slice(),
-        ["--json", "contracts", "--assign-project", "--body-template"].as_slice(),
-        ["--json", "protocol-manager", "--set", "--body-template"].as_slice(),
-        ["--json", "deployments", "--confirm", "--body-template"].as_slice(),
-        ["--json", "projects", "create", "--body-template"].as_slice(),
-    ] {
+    for args in LOCAL_TEMPLATE_INVOCATIONS {
         let output = run_pcl(args);
 
         output.assert_success();

--- a/crates/pcl/cli/tests/parse_output.rs
+++ b/crates/pcl/cli/tests/parse_output.rs
@@ -39,6 +39,25 @@ fn run_pcl(args: &[&str]) -> PclOutput {
     }
 }
 
+/// Like [`run_pcl`], but names a platform. Workflow commands resolve a platform
+/// before dispatch and there is no default, so a run with an empty config dir
+/// would otherwise stop at platform resolution.
+fn run_pcl_with_platform(args: &[&str]) -> PclOutput {
+    let config_dir = tempfile::tempdir().expect("temp config dir");
+    let output = Command::new(env!("CARGO_BIN_EXE_pcl"))
+        .arg("--config-dir")
+        .arg(config_dir.path())
+        .env("PCL_API_URL", "https://linea.phylax.systems")
+        .args(args)
+        .output()
+        .expect("run pcl");
+    PclOutput {
+        success: output.status.success(),
+        stdout: String::from_utf8(output.stdout).expect("utf-8 stdout"),
+        stderr: String::from_utf8(output.stderr).expect("utf-8 stderr"),
+    }
+}
+
 fn assert_json_error(output: &PclOutput, code: &str) {
     output.assert_failure();
     assert!(output.stdout.is_empty());
@@ -186,10 +205,9 @@ fn new_workflow_subcommands_parse_and_emit_structured_templates() {
         ["--json", "releases", "deploy", "--body-template"].as_slice(),
         ["--json", "access", "invite", "--body-template"].as_slice(),
     ] {
-        let output = run_pcl(args);
+        let output = run_pcl_with_platform(args);
 
         output.assert_success();
-        assert!(output.stderr.is_empty(), "{}", output.stderr);
         let envelope: serde_json::Value =
             serde_json::from_str(&output.stdout).expect("json envelope");
         assert_eq!(envelope["status"], "ok", "{envelope}");

--- a/crates/pcl/cli/tests/workflow_cli.rs
+++ b/crates/pcl/cli/tests/workflow_cli.rs
@@ -20,19 +20,25 @@ email = "agent@example.com"
 /// Like [`write_valid_auth_config`], but records the platform that issued the
 /// credentials so authenticated requests to that URL pass the
 /// platform-boundary check.
+///
+/// `issuer_platform_url` under `[auth]` is the value that check reads — the
+/// top-level `platform_url` only says which platform is remembered. A fixture for
+/// "logged in to this platform" sets both, because that is what a real login
+/// writes.
 fn write_valid_auth_config_for_platform(config_dir: &std::path::Path, platform_url: &str) {
+    let platform_url = platform_url.trim_end_matches('/');
     fs::write(
         config_dir.join("config.toml"),
         format!(
-            r#"platform_url = "{}"
+            r#"platform_url = "{platform_url}"
 
 [auth]
 access_token = "test-token"
 refresh_token = "refresh-token"
 expires_at = 4102444800
 email = "agent@example.com"
-"#,
-            platform_url.trim_end_matches('/')
+issuer_platform_url = "{platform_url}"
+"#
         ),
     )
     .expect("write test config");

--- a/crates/pcl/core/Cargo.toml
+++ b/crates/pcl/core/Cargo.toml
@@ -62,3 +62,6 @@ credible = ["dep:assertion-executor", "dep:assertion-verification"]
 [dev-dependencies]
 mockito = "1.2"
 rand = "0.8"
+# `test-util` lets the config-lock timeout be asserted on a paused clock instead
+# of waiting out the real 30-second budget.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pcl/core/src/api.rs
+++ b/crates/pcl/core/src/api.rs
@@ -313,6 +313,50 @@ impl ApiArgs {
     }
 }
 
+/// Whether a workflow command's arguments reach the platform.
+///
+/// `--body-template` prints a static, compiled-in JSON schema: the runner
+/// returns it before constructing a client or fetching the spec. Those runs have
+/// to work on a clean install, because they are how an agent discovers the shape
+/// of a request body before it has chosen a network — requiring a platform to
+/// print a local schema is the tail wagging the dog.
+trait NeedsPlatformUrl {
+    fn needs_platform_url(&self) -> bool;
+}
+
+/// `--body-template` is the only local escape hatch on these commands.
+macro_rules! body_template_gates_platform {
+    ($($args:ty),+ $(,)?) => {
+        $(impl NeedsPlatformUrl for $args {
+            fn needs_platform_url(&self) -> bool {
+                !self.body_template
+            }
+        })+
+    };
+}
+
+/// Commands with no local mode: every invocation talks to the platform.
+macro_rules! always_needs_platform {
+    ($($args:ty),+ $(,)?) => {
+        $(impl NeedsPlatformUrl for $args {
+            fn needs_platform_url(&self) -> bool {
+                true
+            }
+        })+
+    };
+}
+
+body_template_gates_platform!(
+    AssertionsArgs,
+    AccountArgs,
+    ContractsArgs,
+    DeploymentsArgs,
+    IntegrationsArgs,
+    ProtocolManagerArgs,
+);
+
+always_needs_platform!(IncidentsArgs, SearchArgs, EventsArgs);
+
 macro_rules! top_level_workflow_command {
     ($name:ident, $args:ty, $variant:ident, $about:literal, $after_help:literal) => {
         #[derive(clap::Args, Debug)]
@@ -329,6 +373,11 @@ macro_rules! top_level_workflow_command {
             /// given. Startup uses this to skip platform resolution.
             pub fn platform_url_flag(&self) -> Option<&url::Url> {
                 self.globals.platform_url_flag()
+            }
+
+            /// Whether this invocation reaches the platform.
+            pub fn needs_platform_url(&self) -> bool {
+                NeedsPlatformUrl::needs_platform_url(&self.args)
             }
 
             pub async fn run(
@@ -693,6 +742,14 @@ impl ProjectsCommand {
         self.globals.platform_url_flag()
     }
 
+    /// Whether this invocation reaches the platform. Read from the subcommand
+    /// rather than the merged args, because merging consumes them.
+    pub fn needs_platform_url(&self) -> bool {
+        self.command
+            .as_ref()
+            .is_none_or(ProjectsSubcommand::needs_platform_url)
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,
@@ -714,6 +771,15 @@ impl ProjectsCommand {
 }
 
 impl ProjectsSubcommand {
+    /// Whether this subcommand reaches the platform. `--body-template` on a
+    /// write prints a local schema and returns before any client is built.
+    fn needs_platform_url(&self) -> bool {
+        match self {
+            Self::Create(args) => !args.body_template,
+            _ => true,
+        }
+    }
+
     fn into_args(self) -> ProjectsArgs {
         match self {
             Self::List(args) => {
@@ -1153,6 +1219,12 @@ impl ReleasesCommand {
         self.globals.platform_url_flag()
     }
 
+    /// Whether this invocation reaches the platform. Read from the subcommand
+    /// rather than the merged args, because merging consumes them.
+    pub fn needs_platform_url(&self) -> bool {
+        ReleasesSubcommand::needs_platform_url(&self.command)
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,
@@ -1172,6 +1244,18 @@ impl ReleasesCommand {
 }
 
 impl ReleasesSubcommand {
+    /// Whether this subcommand reaches the platform. `--body-template` on a
+    /// body-taking release command prints a local schema and returns before any
+    /// client is built.
+    fn needs_platform_url(&self) -> bool {
+        match self {
+            Self::Create(args) | Self::Preview(args) => !args.body.body_template,
+            Self::Deploy(args) | Self::Remove(args) => !args.body.body_template,
+            Self::RetryCheck(args) => !args.body.body_template,
+            _ => true,
+        }
+    }
+
     fn into_args(self) -> ReleasesArgs {
         match self {
             Self::List(args) => release_project_args(Some(args.project)),
@@ -1421,6 +1505,12 @@ impl AccessCommand {
         self.globals.platform_url_flag()
     }
 
+    /// Whether this invocation reaches the platform. Read from the subcommand
+    /// rather than the merged args, because merging consumes them.
+    pub fn needs_platform_url(&self) -> bool {
+        AccessSubcommand::needs_platform_url(&self.command)
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,
@@ -1435,6 +1525,18 @@ impl AccessCommand {
 }
 
 impl AccessSubcommand {
+    /// Whether this subcommand reaches the platform. `--body-template` on a
+    /// body-taking access command prints a local schema and returns before any
+    /// client is built.
+    fn needs_platform_url(&self) -> bool {
+        match self {
+            Self::Accept(args) => !args.body.body_template,
+            Self::Invite(args) => !args.body.body_template,
+            Self::Resend(args) | Self::Revoke(args) => !args.body.body_template,
+            _ => true,
+        }
+    }
+
     fn into_args(self) -> AccessArgs {
         match self {
             Self::Members(args) => {

--- a/crates/pcl/core/src/api.rs
+++ b/crates/pcl/core/src/api.rs
@@ -160,11 +160,10 @@ pub struct ApiArgs {
     #[arg(
         long = "api-url",
         env = "PCL_API_URL",
-        default_value = crate::config::default_platform_url(),
         global = true,
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    api_url: url::Url,
+    api_url: Option<url::Url>,
 
     #[arg(
         long,
@@ -183,10 +182,28 @@ impl ApiArgs {
     pub(crate) fn headless(api_url: url::Url) -> Self {
         Self {
             command: ApiCommand::Manifest,
-            api_url,
+            api_url: Some(api_url),
             allow_unauthenticated: false,
             refresh_after_401: Cell::new(true),
         }
+    }
+
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.api_url.as_ref()
+    }
+
+    /// Whether this `pcl api` subcommand reaches the platform. `manifest`
+    /// prints a static, compiled-in contract; every other subcommand either
+    /// fetches the `OpenAPI` spec or calls an endpoint.
+    pub fn needs_platform_url(&self) -> bool {
+        !matches!(self.command, ApiCommand::Manifest)
+    }
+
+    /// Platform URL for this run: the explicit `--api-url`/`PCL_API_URL` value
+    /// when given, otherwise the platform resolved during startup.
+    pub(in crate::api) fn resolved_api_url(&self) -> url::Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
     }
 
     /// Executes one workflow operation and returns the response body.
@@ -308,6 +325,12 @@ macro_rules! top_level_workflow_command {
         }
 
         impl $name {
+            /// The explicit `--api-url`/`PCL_API_URL` value, when one was
+            /// given. Startup uses this to skip platform resolution.
+            pub fn platform_url_flag(&self) -> Option<&url::Url> {
+                self.globals.platform_url_flag()
+            }
+
             pub async fn run(
                 self,
                 config: &mut CliConfig,
@@ -665,6 +688,11 @@ struct ProjectWriteArgs {
 }
 
 impl ProjectsCommand {
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.globals.platform_url_flag()
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,
@@ -1120,6 +1148,11 @@ struct ReleaseRemoveCalldataArgs {
 }
 
 impl ReleasesCommand {
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.globals.platform_url_flag()
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,
@@ -1383,6 +1416,11 @@ struct AccessMemberBodyArgs {
 }
 
 impl AccessCommand {
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.globals.platform_url_flag()
+    }
+
     pub async fn run(
         self,
         config: &mut CliConfig,

--- a/crates/pcl/core/src/api.rs
+++ b/crates/pcl/core/src/api.rs
@@ -773,10 +773,23 @@ impl ProjectsCommand {
 impl ProjectsSubcommand {
     /// Whether this subcommand reaches the platform. `--body-template` on a
     /// write prints a local schema and returns before any client is built.
+    ///
+    /// Matched exhaustively rather than with a `_ => true` catch-all: a new
+    /// body-taking variant would otherwise default to requiring a platform and
+    /// silently break its own `--body-template`.
     fn needs_platform_url(&self) -> bool {
         match self {
             Self::Create(args) => !args.body_template,
-            _ => true,
+            Self::Update(args) => !args.write.body_template,
+            Self::List(_)
+            | Self::Mine
+            | Self::Show(_)
+            | Self::Saved(_)
+            | Self::Delete(_)
+            | Self::Save(_)
+            | Self::Unsave(_)
+            | Self::Resolve(_)
+            | Self::Widget(_) => true,
         }
     }
 
@@ -1252,7 +1265,7 @@ impl ReleasesSubcommand {
             Self::Create(args) | Self::Preview(args) => !args.body.body_template,
             Self::Deploy(args) | Self::Remove(args) => !args.body.body_template,
             Self::RetryCheck(args) => !args.body.body_template,
-            _ => true,
+            Self::List(_) | Self::Show(_) | Self::Calldata(_) | Self::BacktestProgress(_) => true,
         }
     }
 
@@ -1528,12 +1541,30 @@ impl AccessSubcommand {
     /// Whether this subcommand reaches the platform. `--body-template` on a
     /// body-taking access command prints a local schema and returns before any
     /// client is built.
+    ///
+    /// Matched exhaustively, including through the `role` and `member` groups:
+    /// their nested variants carry [`WorkflowBodyArgs`] too, and a catch-all arm
+    /// would leave `--body-template` on them demanding a platform.
     fn needs_platform_url(&self) -> bool {
         match self {
             Self::Accept(args) => !args.body.body_template,
             Self::Invite(args) => !args.body.body_template,
             Self::Resend(args) | Self::Revoke(args) => !args.body.body_template,
-            _ => true,
+            Self::Role(args) => {
+                match &args.command {
+                    AccessRoleSubcommand::Update(args) => !args.body.body_template,
+                }
+            }
+            Self::Member(args) => {
+                match &args.command {
+                    AccessMemberSubcommand::Remove(args) => !args.body.body_template,
+                }
+            }
+            Self::Members(_)
+            | Self::Invitations(_)
+            | Self::Pending
+            | Self::Preview(_)
+            | Self::MyRole(_) => true,
         }
     }
 

--- a/crates/pcl/core/src/api/broadcast.rs
+++ b/crates/pcl/core/src/api/broadcast.rs
@@ -1240,6 +1240,7 @@ mod tests {
         let api = ApiArgs::headless(server.url().parse().unwrap());
         let mut config = CliConfig {
             auth: Some(crate::config::UserAuth {
+                issuer_platform_url: Some(server.url()),
                 access_token: "access-token".to_string(),
                 refresh_token: "refresh-token".to_string(),
                 expires_at: Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap(),

--- a/crates/pcl/core/src/api/runner.rs
+++ b/crates/pcl/core/src/api/runner.rs
@@ -415,8 +415,12 @@ impl ApiArgs {
             }
             ApiCommand::Coverage { records, markdown } => {
                 let spec = self.fetch_openapi(config).await?;
-                let coverage =
-                    api_coverage(&spec, &request_log_path, *records, self.api_url.as_str())?;
+                let coverage = api_coverage(
+                    &spec,
+                    &request_log_path,
+                    *records,
+                    self.resolved_api_url().as_str(),
+                )?;
                 if let Some(path) = markdown {
                     write_api_coverage_markdown(path, &coverage)?;
                 }
@@ -1119,7 +1123,7 @@ impl ApiArgs {
             return Ok(false);
         }
 
-        match refresh_stored_auth(config, &self.api_url, cli_args, true).await {
+        match refresh_stored_auth(config, &self.resolved_api_url(), cli_args, true).await {
             Ok(_) => Ok(true),
             Err(AuthError::RefreshEndpointNotFound { .. }) => {
                 self.refresh_after_401.set(false);
@@ -1560,12 +1564,12 @@ impl ApiArgs {
         };
         // Never refresh against — or later authenticate to — a platform the
         // stored credentials were not issued by.
-        crate::auth::ensure_credential_platform(config, &self.api_url)
+        crate::auth::ensure_credential_platform(config, &self.resolved_api_url())
             .map_err(ApiCommandError::PlatformMismatch)?;
         let now = chrono::Utc::now();
         let seconds_remaining = (auth.expires_at - now).num_seconds();
         if auth.expires_at <= now || seconds_remaining <= crate::config::AUTH_EXPIRES_SOON_SECONDS {
-            refresh_stored_auth(config, &self.api_url, cli_args, false)
+            refresh_stored_auth(config, &self.resolved_api_url(), cli_args, false)
                 .await
                 .map_err(ApiCommandError::AuthRefresh)?;
         }
@@ -1640,7 +1644,7 @@ impl ApiArgs {
         );
 
         if attach_auth && let Some(auth) = &config.auth {
-            match crate::auth::ensure_credential_platform(config, &self.api_url) {
+            match crate::auth::ensure_credential_platform(config, &self.resolved_api_url()) {
                 Err(error) if require_auth => {
                     return Err(ApiCommandError::PlatformMismatch(error));
                 }
@@ -1680,7 +1684,7 @@ impl ApiArgs {
         attach_auth: bool,
         require_auth: bool,
     ) -> Result<GeneratedClient, ApiCommandError> {
-        let mut base = self.api_url.clone();
+        let mut base = self.resolved_api_url();
         base.set_path("/api/v1");
         let http_client = self.http_client(config, attach_auth, require_auth)?;
         Ok(GeneratedClient::new_with_client(base.as_str(), http_client))
@@ -1705,7 +1709,7 @@ impl ApiArgs {
             return Err(ApiCommandError::InvalidPath(path.to_string()));
         }
 
-        let mut url = self.api_url.clone();
+        let mut url = self.resolved_api_url();
         url.set_path(&format!("/api/v1{path}"));
         Ok(url)
     }

--- a/crates/pcl/core/src/api/tests.rs
+++ b/crates/pcl/core/src/api/tests.rs
@@ -76,6 +76,7 @@ fn auth_config(
     CliConfig {
         rpc: BTreeMap::default(),
         auth: Some(UserAuth {
+            issuer_platform_url: None,
             access_token: access_token.to_string(),
             refresh_token: refresh_token.to_string(),
             expires_at: Utc.with_ymd_and_hms(expires_year, 1, 1, 0, 0, 0).unwrap(),
@@ -999,7 +1000,7 @@ async fn authenticated_project_slug_resolution_attaches_auth() {
     let api = test_api(server.url(), false);
     let mut config = valid_auth_config("access-token", "refresh-token");
     // The credentials were issued by the mock platform.
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     let request = test_workflow_request_for_operation(
         WorkflowOperation::new(HttpMethod::Get, "get_projects_project_id")
             .path_param("project_id", "private-slug"),
@@ -1039,7 +1040,7 @@ async fn project_slug_resolution_errors_preserve_http_metadata() {
     let api = test_api(server.url(), false);
     let mut config = valid_auth_config("access-token", "refresh-token");
     // The credentials were issued by the mock platform.
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     let request = test_workflow_request_for_operation(
         WorkflowOperation::new(HttpMethod::Get, "get_projects_project_id")
             .path_param("project_id", "missing-slug"),
@@ -1392,7 +1393,7 @@ async fn authenticated_workflow_retries_once_after_refresh_on_401() {
     };
     let mut config = valid_auth_config("old_access", "old_refresh");
     // The credentials were issued by the mock platform.
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     config.write_to_file(&cli_args).unwrap();
     let request = test_workflow_request(
         HttpMethod::Get,
@@ -1448,7 +1449,7 @@ async fn raw_401_preserves_original_error_when_refresh_endpoint_is_missing() {
     };
     let mut config = valid_auth_config("old_access", "old_refresh");
     // The credentials were issued by the mock platform.
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     config.write_to_file(&cli_args).unwrap();
     let input = ApiRequestInput {
         method: HttpMethod::Get,
@@ -1518,7 +1519,7 @@ async fn incident_stats_401_propagates_original_http_error() {
     };
     let mut config = valid_auth_config("old_access", "old_refresh");
     // The credentials were issued by the mock platform.
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     config.write_to_file(&cli_args).unwrap();
     let args = IncidentsArgs {
         project_id: Some(project_id.to_string()),
@@ -1622,7 +1623,7 @@ async fn uploads_project_image_and_returns_storage_path() {
         .await;
     let api = test_api(server.url(), false);
     let mut config = valid_auth_config("access-token", "refresh-token");
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
 
     let dir = tempfile::tempdir().unwrap();
     let image = dir.path().join("logo.png");
@@ -1686,7 +1687,7 @@ async fn project_image_upload_refreshes_auth_before_the_multipart_request() {
         ..CliArgs::default()
     };
     let mut config = expired_auth_config("old-access", "old-refresh");
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     config.write_to_file(&cli_args).unwrap();
     let image_dir = tempfile::tempdir().unwrap();
     let image = image_dir.path().join("logo.png");
@@ -1753,7 +1754,7 @@ async fn project_image_upload_refreshes_and_retries_after_401() {
     // proactive `ensure_request_auth` check leaves it untouched, so only a
     // reactive refresh-on-401 can recover.
     let mut config = valid_auth_config("old-access", "old-refresh");
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     config.write_to_file(&cli_args).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
@@ -1783,7 +1784,7 @@ async fn malformed_project_body_fails_before_image_upload() {
         .await;
     let api = test_api(server.url(), false);
     let mut config = valid_auth_config("access-token", "refresh-token");
-    config.platform_url = Some(server.url());
+    config.set_test_platform(&server.url());
     let dir = tempfile::tempdir().unwrap();
     let image = dir.path().join("logo.png");
     std::fs::write(&image, b"png").unwrap();

--- a/crates/pcl/core/src/api/tests.rs
+++ b/crates/pcl/core/src/api/tests.rs
@@ -31,7 +31,7 @@ fn test_request_log_path() -> &'static Path {
 fn test_api(api_url: impl AsRef<str>, allow_unauthenticated: bool) -> ApiArgs {
     ApiArgs {
         command: ApiCommand::Manifest,
-        api_url: api_url.as_ref().parse().unwrap(),
+        api_url: Some(api_url.as_ref().parse().unwrap()),
         allow_unauthenticated,
         refresh_after_401: Cell::new(true),
     }

--- a/crates/pcl/core/src/api/workflow_options.rs
+++ b/crates/pcl/core/src/api/workflow_options.rs
@@ -13,11 +13,10 @@ pub(in crate::api) struct ApiWorkflowOptions {
     #[arg(
         long = "api-url",
         env = "PCL_API_URL",
-        default_value = crate::config::default_platform_url(),
         global = true,
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    api_url: url::Url,
+    api_url: Option<url::Url>,
 
     #[arg(
         long,
@@ -28,6 +27,11 @@ pub(in crate::api) struct ApiWorkflowOptions {
 }
 
 impl ApiWorkflowOptions {
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub(in crate::api) fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.api_url.as_ref()
+    }
+
     pub(in crate::api) async fn run(
         self,
         command: WorkflowCommand,

--- a/crates/pcl/core/src/apply.rs
+++ b/crates/pcl/core/src/apply.rs
@@ -7,7 +7,6 @@ use crate::verify::{
     run_verification,
 };
 use crate::{
-    DEFAULT_PLATFORM_URL,
     abi,
     api::generated_operation_path,
     client::{
@@ -112,13 +111,38 @@ pub struct ApplyArgs {
         long = "api-url",
         env = "PCL_API_URL",
         value_hint = ValueHint::Url,
-        default_value = crate::config::default_platform_url(),
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    pub api_url: url::Url,
+    pub api_url: Option<url::Url>,
 }
 
 impl ApplyArgs {
+    /// Platform URL for this run: the explicit `-u`/`PCL_API_URL` value when
+    /// given, otherwise the platform resolved during startup.
+    fn resolved_api_url(&self) -> url::Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
+
+    /// Whether this run reaches the platform. `--dry-run` builds and verifies
+    /// locally, so validating assertions must not require choosing a network.
+    ///
+    /// A dry run still needs a platform in one case — selecting a project when
+    /// `credible.toml` records none — which depends on file contents rather
+    /// than the command line, so that path resolves the platform as a
+    /// recoverable error instead.
+    pub fn needs_platform_url(&self) -> bool {
+        !self.dry_run
+    }
+
+    /// Platform URL for a path a dry run may reach, as a recoverable error
+    /// when no platform was resolved at startup.
+    fn try_resolved_api_url(&self) -> Result<url::Url, ApplyError> {
+        match &self.api_url {
+            Some(api_url) => Ok(api_url.clone()),
+            None => Ok(crate::platform::require_active_platform()?),
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run(&self, cli_args: &CliArgs, config: &mut CliConfig) -> Result<(), ApplyError> {
         let output_mode = cli_args.output_mode();
@@ -134,7 +158,8 @@ impl ApplyArgs {
                 ));
             }
             None => {
-                Self::ensure_fresh_auth(config, cli_args, &self.api_url).await?;
+                let api_url = self.try_resolved_api_url()?;
+                Self::ensure_fresh_auth(config, cli_args, &api_url).await?;
                 self.select_project(config).await?
             }
         };
@@ -152,7 +177,7 @@ impl ApplyArgs {
             return Ok(());
         }
 
-        Self::ensure_fresh_auth(config, cli_args, &self.api_url).await?;
+        Self::ensure_fresh_auth(config, cli_args, &self.resolved_api_url()).await?;
         let client = self.build_client(config)?;
         let preview = Self::call_preview(&client, &project_id, &payload).await?;
 
@@ -186,7 +211,7 @@ impl ApplyArgs {
             if output_mode != OutputMode::Human {
                 return Err(ApplyError::JsonConfirmationRequiresYes);
             }
-            if !confirm_apply()? {
+            if !confirm_apply(&self.resolved_api_url())? {
                 return Err(ApplyError::ApplyCancelled);
             }
         }
@@ -214,7 +239,7 @@ impl ApplyArgs {
             return Ok(());
         }
 
-        Self::print_release_success(self.api_url.as_str(), &project_id, &release);
+        Self::print_release_success(self.resolved_api_url().as_str(), &project_id, &release);
         Ok(())
     }
 
@@ -233,15 +258,17 @@ impl ApplyArgs {
         if dry_run {
             parts.push("--dry-run".to_string());
         }
-        if self.api_url.as_str().trim_end_matches('/') != DEFAULT_PLATFORM_URL {
+        // Only an explicit override needs reproducing: without a flag the
+        // re-run resolves the same remembered platform.
+        if let Some(api_url) = &self.api_url {
             parts.push("--api-url".to_string());
-            parts.push(shell_word(self.api_url.as_str()));
+            parts.push(shell_word(api_url.as_str()));
         }
         parts.join(" ")
     }
 
     pub(crate) fn build_client(&self, config: &CliConfig) -> Result<GeneratedClient, ApplyError> {
-        authenticated_client(config, &self.api_url).map_err(client_error_to_apply)
+        authenticated_client(config, &self.resolved_api_url()).map_err(client_error_to_apply)
     }
 
     pub(crate) async fn ensure_fresh_auth(
@@ -629,7 +656,17 @@ pub(crate) fn canonicalize_root(root: &Path) -> Result<PathBuf, ApplyError> {
     })
 }
 
-pub(crate) fn confirm_apply() -> Result<bool, ApplyError> {
+/// Confirmation header naming the platform the release lands on, so a wrong
+/// network is caught by eye before the change is applied.
+pub(crate) fn apply_target_summary(platform_url: &Url) -> String {
+    format!(
+        "Applying to {}",
+        crate::platform::describe_platform(platform_url)
+    )
+}
+
+pub(crate) fn confirm_apply(platform_url: &Url) -> Result<bool, ApplyError> {
+    eprintln!("{}", apply_target_summary(platform_url));
     eprint!("Do you want to apply these changes? [Y/n]: ");
     stderr().flush().map_err(|e| {
         ApplyError::Io {
@@ -688,6 +725,62 @@ mod tests {
         StateMutability,
     };
     use pcl_phoundry::build_and_flatten::BuildAndFlatOutput;
+
+    fn apply_args_with_url(api_url: Option<&str>) -> ApplyArgs {
+        ApplyArgs {
+            root: PathBuf::from("."),
+            config: PathBuf::from("assertions/credible.toml"),
+            yes: false,
+            dry_run: false,
+            api_url: api_url.map(|url| url.parse().expect("test URL parses")),
+        }
+    }
+
+    #[test]
+    fn apply_confirmation_names_the_target_network() {
+        assert_eq!(
+            apply_target_summary(&"https://linea.phylax.systems".parse().expect("test URL")),
+            "Applying to Linea Mainnet (linea.phylax.systems)"
+        );
+        assert_eq!(
+            apply_target_summary(&"https://ethereum.phylax.systems".parse().expect("test URL")),
+            "Applying to Ethereum Mainnet (ethereum.phylax.systems)"
+        );
+        // A shadow or staging target has no network name; show it verbatim
+        // rather than mislabelling it.
+        assert_eq!(
+            apply_target_summary(&"https://shadow.phylax.example/".parse().expect("test URL")),
+            "Applying to https://shadow.phylax.example"
+        );
+    }
+
+    #[test]
+    fn reproduced_command_includes_only_an_explicit_platform() {
+        let root = Path::new("/tmp/project");
+
+        // An explicit override has to be reproduced or the re-run would target
+        // a different platform.
+        let explicit = apply_args_with_url(Some("https://shadow.phylax.example"));
+        let command = explicit.apply_command(root, true, false);
+        assert!(
+            command.contains("--api-url https://shadow.phylax.example"),
+            "{command}"
+        );
+
+        // Without a flag the re-run resolves the same remembered platform, so
+        // there is nothing to pin.
+        let resolved = apply_args_with_url(None);
+        let command = resolved.apply_command(root, true, false);
+        assert!(!command.contains("--api-url"), "{command}");
+    }
+
+    #[test]
+    fn dry_run_needs_no_platform_but_a_real_apply_does() {
+        let mut args = apply_args_with_url(None);
+        assert!(args.needs_platform_url());
+        args.dry_run = true;
+        assert!(!args.needs_platform_url());
+    }
 
     fn make_built(abi: JsonAbi) -> BuildAndFlatOutput {
         BuildAndFlatOutput {

--- a/crates/pcl/core/src/assertion_spec.rs
+++ b/crates/pcl/core/src/assertion_spec.rs
@@ -1,8 +1,9 @@
 //! Which assertion spec a target platform runs, and whether a project's
 //! assertions are written against the V2 spec.
 //!
-//! The production platform (`app.phylax.systems`, Linea) runs the V1 assertion
-//! spec. Assertions written against the V2 triggers and precompiles
+//! The Linea platform (`linea.phylax.systems`) runs the V1 assertion spec;
+//! Ethereum (`ethereum.phylax.systems`) runs V2. Assertions written against the
+//! V2 triggers and precompiles
 //! (`registerTxEndTrigger`, `ph.staticcallAt`, the fork-id reads, the
 //! protection-suite precompiles, the cumulative-flow circuit breakers) do not
 //! run there, so `pcl deploy` and `pcl auth login` warn instead of letting the
@@ -36,7 +37,23 @@ pub const LINEA_SEPOLIA_CHAIN_ID: u64 = 59141;
 const V1_ONLY_CHAIN_IDS: [u64; 2] = [LINEA_MAINNET_CHAIN_ID, LINEA_SEPOLIA_CHAIN_ID];
 
 /// Platform hosts that run the V1 assertion spec.
-const V1_ONLY_PLATFORM_HOSTS: [&str; 1] = ["app.phylax.systems"];
+///
+/// `linea.phylax.systems` serves the Linea platform, which runs V1;
+/// `ethereum.phylax.systems` runs V2 and is deliberately absent.
+/// `app.phylax.systems` is kept because it is now only a router page and no
+/// longer serves the API — an explicit `-u https://app.phylax.systems` from an
+/// older habit or script should still get the notice rather than silently
+/// nothing.
+///
+/// This host list is a proxy, and a poor one: the spec a deploy actually needs is
+/// a property of the executor behind a platform and the chain it serves, not of a
+/// hostname, and it has to be maintained by hand every time a platform moves.
+/// `V1_ONLY_CHAIN_IDS` is the more reliable signal and the only one available
+/// once the chain is known — but `pcl auth login` has no project or chain in
+/// scope, so the host is all it has. Replacing both with a capability the
+/// platform reports is tracked as follow-up work; until then a deploy to a
+/// network that cannot run the assertions is warned about, not blocked.
+const V1_ONLY_PLATFORM_HOSTS: [&str; 2] = ["linea.phylax.systems", "app.phylax.systems"];
 
 /// Warning code used in machine output.
 pub const V2_SPEC_UNSUPPORTED_CODE: &str = "assertion_spec.v2_unsupported";
@@ -227,24 +244,35 @@ fn unique_assertion_paths(credible: &CredibleToml) -> Vec<&str> {
 ///
 /// `chain_id` is `None` when the target chain is not known yet (a `--dry-run`
 /// without `--chain-id`); the platform check alone still decides.
+///
+/// `platform_url` is `None` on a local `--dry-run` that never chose a platform.
+/// The chain check still applies — `--chain-id 59144` is enough to know the
+/// assertions will not run — so a plan does not have to pick a network to be
+/// warned.
 pub fn deploy_warning(
-    platform_url: &Url,
+    platform_url: Option<&Url>,
     chain_id: Option<u64>,
     findings: &[V2SpecFinding],
 ) -> Option<String> {
     if findings.is_empty() {
         return None;
     }
-    let platform_only_v1 = !platform_supports_v2(platform_url);
+    let platform_only_v1 = platform_url.is_some_and(|url| !platform_supports_v2(url));
     let chain_only_v1 = chain_id.is_some_and(|chain_id| !chain_supports_v2(chain_id));
     if !platform_only_v1 && !chain_only_v1 {
         return None;
     }
 
-    let platform = platform_url.as_str().trim_end_matches('/');
-    let target = match chain_id.filter(|chain_id| !chain_supports_v2(*chain_id)) {
-        Some(chain_id) => format!("{platform} ({})", chain_label(chain_id)),
-        None => platform.to_string(),
+    let platform = platform_url.map(crate::platform::redact_platform_url);
+    let target = match (
+        platform,
+        chain_id.filter(|chain_id| !chain_supports_v2(*chain_id)),
+    ) {
+        (Some(platform), Some(chain_id)) => format!("{platform} ({})", chain_label(chain_id)),
+        (Some(platform), None) => platform,
+        (None, Some(chain_id)) => format!("The target chain ({})", chain_label(chain_id)),
+        // Unreachable: one of the two checks above was true to get here.
+        (None, None) => return None,
     };
 
     let mut message =
@@ -264,16 +292,19 @@ pub fn deploy_warning(
 }
 
 /// Machine-output form of a warning message.
+///
+/// `platform_url` is `None` on a local plan that chose no platform, and is
+/// reported as `null` rather than invented.
 pub fn warning_json(
     message: &str,
-    platform_url: &Url,
+    platform_url: Option<&Url>,
     chain_id: Option<u64>,
     findings: &[V2SpecFinding],
 ) -> Value {
     json!({
         "code": V2_SPEC_UNSUPPORTED_CODE,
         "message": message,
-        "platform_url": platform_url.as_str(),
+        "platform_url": platform_url.map(crate::platform::redact_platform_url),
         "chain_id": chain_id,
         "assertion_spec": "v1",
         "files": findings
@@ -291,8 +322,8 @@ pub fn login_notice(platform_url: &Url) -> Option<String> {
         return None;
     }
     Some(format!(
-        "{} (Linea) runs the V1 assertion spec. Do not write assertions against the V2 spec: V2 triggers and precompiles (registerTxEndTrigger, registerFnCallTrigger, ph.staticcallAt, the cumulative-flow circuit breakers) are not supported on this platform.",
-        platform_url.as_str().trim_end_matches('/'),
+        "{} runs the V1 assertion spec. Do not write assertions against the V2 spec: V2 triggers and precompiles (registerTxEndTrigger, registerFnCallTrigger, ph.staticcallAt, the cumulative-flow circuit breakers) are not supported on this platform.",
+        crate::platform::redact_platform_url(platform_url),
     ))
 }
 
@@ -301,7 +332,7 @@ pub fn login_warning_json(message: &str, platform_url: &Url) -> Value {
     json!({
         "code": V2_SPEC_UNSUPPORTED_CODE,
         "message": message,
-        "platform_url": platform_url.as_str(),
+        "platform_url": crate::platform::redact_platform_url(platform_url),
         "assertion_spec": "v1",
     })
 }
@@ -412,17 +443,47 @@ mod tests {
     }
 
     #[test]
-    fn production_and_linea_are_v1_only() {
+    fn linea_is_v1_only_and_ethereum_runs_v2() {
+        // Both networks the selector offers, so neither choice can silently
+        // lose its compatibility notice when a platform is renamed again.
+        assert!(!platform_supports_v2(&url("https://linea.phylax.systems")));
+        assert!(!platform_supports_v2(&url(
+            "https://Linea.Phylax.Systems/dashboard"
+        )));
+        assert!(platform_supports_v2(&url(
+            "https://ethereum.phylax.systems"
+        )));
+
+        // Kept for anyone still passing the old host explicitly.
         assert!(!platform_supports_v2(&url("https://app.phylax.systems")));
         assert!(!platform_supports_v2(&url(
             "https://APP.Phylax.Systems/dashboard"
         )));
+
         assert!(!chain_supports_v2(LINEA_MAINNET_CHAIN_ID));
         assert!(!chain_supports_v2(LINEA_SEPOLIA_CHAIN_ID));
 
         assert!(platform_supports_v2(&url("https://dev.phylax.systems")));
         assert!(platform_supports_v2(&url("http://localhost:3000")));
         assert!(chain_supports_v2(84532));
+    }
+
+    /// Every network in the selector has a decided spec capability. A network
+    /// added to the picker without deciding this would silently inherit "runs
+    /// V2", which is the wrong default: it means no warning at all.
+    #[test]
+    fn every_selectable_network_has_a_decided_spec_capability() {
+        for network in crate::platform::SELECTABLE_NETWORKS {
+            let expected_v2 = match network {
+                crate::platform::Network::EthereumMainnet => true,
+                crate::platform::Network::LineaMainnet => false,
+            };
+            assert_eq!(
+                platform_supports_v2(&network.url()),
+                expected_v2,
+                "{network} has the wrong assertion-spec capability"
+            );
+        }
     }
 
     #[test]
@@ -887,7 +948,7 @@ mod tests {
             ],
         }];
 
-        let warning = deploy_warning(&url("https://app.phylax.systems"), None, &findings)
+        let warning = deploy_warning(Some(&url("https://app.phylax.systems")), None, &findings)
             .expect("warning on the V1-only platform");
         assert!(warning.contains("V1 assertion spec"), "{warning}");
         assert!(warning.contains("assertions/src/V2.a.sol"), "{warning}");
@@ -897,7 +958,7 @@ mod tests {
         );
 
         let with_chain = deploy_warning(
-            &url("https://app.phylax.systems"),
+            Some(&url("https://app.phylax.systems")),
             Some(LINEA_MAINNET_CHAIN_ID),
             &findings,
         )
@@ -917,7 +978,7 @@ mod tests {
 
         assert!(
             deploy_warning(
-                &url("https://dev.phylax.systems"),
+                Some(&url("https://dev.phylax.systems")),
                 Some(LINEA_SEPOLIA_CHAIN_ID),
                 &findings
             )
@@ -932,9 +993,14 @@ mod tests {
             markers: vec!["registerTxEndTrigger".to_string()],
         }];
 
-        assert!(deploy_warning(&url("https://app.phylax.systems"), None, &[]).is_none());
+        assert!(deploy_warning(Some(&url("https://app.phylax.systems")), None, &[]).is_none());
         assert!(
-            deploy_warning(&url("https://dev.phylax.systems"), Some(84532), &findings).is_none()
+            deploy_warning(
+                Some(&url("https://dev.phylax.systems")),
+                Some(84532),
+                &findings
+            )
+            .is_none()
         );
     }
 
@@ -953,10 +1019,15 @@ mod tests {
             markers: vec!["staticcallAt".to_string()],
         }];
         let platform = url("https://app.phylax.systems");
-        let message =
-            deploy_warning(&platform, Some(LINEA_MAINNET_CHAIN_ID), &findings).expect("warning");
+        let message = deploy_warning(Some(&platform), Some(LINEA_MAINNET_CHAIN_ID), &findings)
+            .expect("warning");
 
-        let value = warning_json(&message, &platform, Some(LINEA_MAINNET_CHAIN_ID), &findings);
+        let value = warning_json(
+            &message,
+            Some(&platform),
+            Some(LINEA_MAINNET_CHAIN_ID),
+            &findings,
+        );
 
         assert_eq!(value["code"], V2_SPEC_UNSUPPORTED_CODE);
         assert_eq!(value["chain_id"], 59144);

--- a/crates/pcl/core/src/auth.rs
+++ b/crates/pcl/core/src/auth.rs
@@ -9,6 +9,7 @@ use crate::{
     config::{
         AUTH_EXPIRES_SOON_SECONDS,
         CliConfig,
+        ConfigLock,
         UserAuth,
         access_token_expires_at,
     },
@@ -52,14 +53,10 @@ use serde_json::{
     Value,
     json,
 };
-use std::{
-    fs::OpenOptions,
-    io::{
-        self,
-        BufRead,
-        Write,
-    },
-    path::PathBuf,
+use std::io::{
+    self,
+    BufRead,
+    Write,
 };
 use tokio::time::{
     Duration,
@@ -74,10 +71,6 @@ const INITIAL_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const MAX_POLL_INTERVAL: Duration = Duration::from_secs(10);
 /// Overall polling budget, matching the previous 150 x 2s behavior.
 const POLL_TIMEOUT: Duration = Duration::from_mins(5);
-/// Maximum time to wait for another local CLI process to finish rotating auth.
-const REFRESH_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
-/// Poll interval while waiting on the local refresh lock.
-const REFRESH_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub struct RefreshOutcome {
@@ -91,10 +84,6 @@ struct RefreshErrorDetails {
     request_id: Option<String>,
     code: Option<String>,
     message: Option<String>,
-}
-
-struct RefreshLock {
-    path: PathBuf,
 }
 
 /// Authentication commands for the PCL CLI
@@ -1238,7 +1227,15 @@ pub async fn refresh_stored_auth(
     cli_args: &CliArgs,
     force: bool,
 ) -> Result<RefreshOutcome, AuthError> {
-    let _lock = RefreshLock::acquire(cli_args).await?;
+    // The same lock platform selection takes, so the two cannot interleave and
+    // overwrite each other's merge. A timeout keeps its existing auth-shaped
+    // error, since to the user this is still a refresh that could not proceed.
+    let _lock = ConfigLock::acquire(cli_args).await.map_err(|error| {
+        match error {
+            ConfigError::LockTimeout => AuthError::RefreshLockTimeout,
+            other => AuthError::ConfigError(other),
+        }
+    })?;
     let mut disk_config = CliConfig::read_from_file(cli_args).map_err(AuthError::ConfigError)?;
     disk_config.normalize_auth_expiry_from_access_token();
     if disk_config.auth.is_some() || config.auth.is_none() {
@@ -1401,46 +1398,6 @@ fn persist_refreshed_auth(
         reason: "refreshed",
         request_id,
     })
-}
-
-impl RefreshLock {
-    async fn acquire(cli_args: &CliArgs) -> Result<Self, AuthError> {
-        let path = CliConfig::config_file_path(cli_args).with_extension("toml.lock");
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|error| AuthError::ConfigError(ConfigError::WriteError(error)))?;
-        }
-        let deadline = Instant::now() + REFRESH_LOCK_TIMEOUT;
-        loop {
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(mut file) => {
-                    let _ = writeln!(
-                        file,
-                        "pid={} acquired_at={}",
-                        std::process::id(),
-                        chrono::Utc::now().to_rfc3339()
-                    );
-                    let _ = file.sync_all();
-                    return Ok(Self { path });
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if Instant::now() >= deadline {
-                        return Err(AuthError::RefreshLockTimeout);
-                    }
-                    sleep(REFRESH_LOCK_POLL_INTERVAL).await;
-                }
-                Err(error) => {
-                    return Err(AuthError::ConfigError(ConfigError::WriteError(error)));
-                }
-            }
-        }
-    }
-}
-
-impl Drop for RefreshLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
 }
 
 async fn refresh_error_details(response: reqwest::Response) -> RefreshErrorDetails {

--- a/crates/pcl/core/src/auth.rs
+++ b/crates/pcl/core/src/auth.rs
@@ -878,7 +878,12 @@ impl AuthCommand {
                 } else {
                     spinner.finish_with_message("✅ Authentication successful!");
                 }
-                update_config_from_verified_status(config, status, auth_response.expires_at)?;
+                update_config_from_verified_status(
+                    config,
+                    status,
+                    auth_response.expires_at,
+                    &self.effective_auth_url(),
+                )?;
                 self.remember_platform_url(config);
                 if !json_output {
                     Self::display_success_message(config)?;
@@ -909,6 +914,7 @@ impl AuthCommand {
                 config,
                 status,
                 expires_at.unwrap_or_else(default_poll_fallback_expires_at),
+                &self.effective_auth_url(),
             )?;
             self.remember_platform_url(config);
             let mut output = self.with_v2_spec_warning(self.status_envelope(config));
@@ -981,7 +987,9 @@ impl AuthCommand {
                 "mode": "local",
                 "reason": "platform_mismatch",
                 "credential_platform": credential_platform_label(config),
-                "requested_platform": self.effective_auth_url().as_str(),
+                "requested_platform": crate::platform::redact_platform_url(
+                    &self.effective_auth_url()
+                ),
             });
         }
 
@@ -1076,7 +1084,7 @@ impl AuthCommand {
                 expires_at: auth.expires_at,
                 platform_url: self.reportable_auth_url().map_or_else(
                     || "no platform selected".to_string(),
-                    |url| crate::platform::trim_platform_url(&url),
+                    |url| crate::platform::redact_platform_url(&url),
                 ),
             });
         }
@@ -1165,19 +1173,28 @@ impl AuthCommand {
 
 /// The platform the stored credentials were issued by, when one is recorded.
 ///
-/// Credentials stored by an earlier `pcl` — which deliberately left the
-/// remembered platform empty for production logins — have no recorded
-/// platform. There is no longer a default to assume them into, so they belong
-/// to an unknown platform.
+/// Read from the credentials themselves, never from
+/// [`CliConfig::platform_url`]. The remembered platform is *selection* state:
+/// startup rewrites it from `-u`, and an interactive pick writes it before the
+/// command runs. Deriving provenance from it would let either of those rebind a
+/// stored token to a platform that never issued it, and the boundary check
+/// below would then compare a value against itself.
+///
+/// Credentials stored by an earlier `pcl` recorded no issuer. There is no
+/// default to assume them into, so they belong to an unknown platform.
 fn credential_platform(config: &CliConfig) -> Option<&str> {
-    config.platform_url.as_deref()
+    config.auth.as_ref()?.issuer_platform_url.as_deref()
 }
 
 /// Label for the credential platform in operator-facing output.
+///
+/// Redacted: a login through `-u https://user:secret@host` records that URL
+/// verbatim as the issuer, and this label ends up in error messages that reach
+/// terminals and CI logs.
 fn credential_platform_label(config: &CliConfig) -> String {
     credential_platform(config).map_or_else(
         || "an unrecorded platform (logged in with an earlier pcl release)".to_string(),
-        ToString::to_string,
+        crate::platform::redact_stored_platform_url,
     )
 }
 
@@ -1211,7 +1228,7 @@ pub fn ensure_credential_platform(config: &CliConfig, target: &url::Url) -> Resu
     }
     Err(AuthError::PlatformMismatch {
         credential_platform: credential_platform_label(config),
-        requested: target.as_str().trim_end_matches('/').to_string(),
+        requested: crate::platform::redact_platform_url(target),
     })
 }
 
@@ -1256,6 +1273,11 @@ pub async fn refresh_stored_auth(
     let user_id = auth.user_id;
     let wallet_address = auth.wallet_address;
     let email = auth.email.clone();
+    // A refresh rotates the token pair without changing who issued it, so the
+    // recorded issuer carries over. `ensure_credential_platform` above proves
+    // it is present and equal to `auth_url`, so re-deriving it here would be
+    // the same value by a longer route.
+    let issuer_platform_url = auth.issuer_platform_url.clone();
     let refresh_token = auth.refresh_token.clone();
     let refresh_token =
         PostAuthRefreshBodyRefreshToken::try_from(refresh_token.as_str()).map_err(|error| {
@@ -1271,9 +1293,12 @@ pub async fn refresh_stored_auth(
                 config,
                 cli_args,
                 response.into_inner(),
-                user_id,
-                wallet_address,
-                email,
+                RefreshedIdentity {
+                    user_id,
+                    wallet_address,
+                    email,
+                    issuer_platform_url,
+                },
                 request_id,
             )
         }
@@ -1342,13 +1367,20 @@ async fn handle_refresh_error(
     }
 }
 
+/// The parts of the stored credentials a refresh preserves: a rotation replaces
+/// the token pair and its expiry, and nothing else.
+struct RefreshedIdentity {
+    user_id: Option<Uuid>,
+    wallet_address: Option<Address>,
+    email: Option<String>,
+    issuer_platform_url: Option<String>,
+}
+
 fn persist_refreshed_auth(
     config: &mut CliConfig,
     cli_args: &CliArgs,
     body: PostAuthRefreshResponse,
-    user_id: Option<Uuid>,
-    wallet_address: Option<Address>,
-    email: Option<String>,
+    identity: RefreshedIdentity,
     request_id: Option<String>,
 ) -> Result<RefreshOutcome, AuthError> {
     config.auth = Some(UserAuth {
@@ -1356,9 +1388,10 @@ fn persist_refreshed_auth(
         refresh_token: body.refresh_token,
         expires_at: body.expires_at,
         refresh_expires_at: Some(body.refresh_expires_at),
-        user_id,
-        wallet_address,
-        email,
+        user_id: identity.user_id,
+        wallet_address: identity.wallet_address,
+        email: identity.email,
+        issuer_platform_url: identity.issuer_platform_url,
     });
     config
         .write_to_file(cli_args)
@@ -1631,10 +1664,17 @@ fn auth_challenge_reason(config: &CliConfig, force: bool) -> AuthChallengeReason
     }
 }
 
+/// Stores freshly verified credentials, recording the platform that issued
+/// them.
+///
+/// `issuer` is the platform this login actually talked to, so it is the only
+/// correct provenance for the tokens being stored — and the one value the
+/// boundary check may later trust.
 fn update_config_from_verified_status(
     config: &mut CliConfig,
     status: GetCliAuthStatusResponse,
     fallback_expires_at: chrono::DateTime<chrono::Utc>,
+    issuer: &url::Url,
 ) -> Result<(), AuthError> {
     let token = status.token.ok_or_else(|| {
         AuthError::InvalidAuthData("Verified but missing access token".to_string())
@@ -1658,6 +1698,7 @@ fn update_config_from_verified_status(
         user_id: Some(user_id),
         wallet_address,
         email: status.email,
+        issuer_platform_url: Some(crate::platform::trim_platform_url(issuer)),
     });
     Ok(())
 }
@@ -1700,6 +1741,7 @@ mod tests {
         CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "test_token".to_string(),
                 refresh_token: "test_refresh".to_string(),
                 expires_at: Utc.with_ymd_and_hms(2099, 12, 31, 0, 0, 0).unwrap(),
@@ -1731,6 +1773,7 @@ mod tests {
         CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "old_access".to_string(),
                 refresh_token: "old_refresh".to_string(),
                 expires_at: Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap(),
@@ -2025,7 +2068,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let cli_args = test_cli_args(temp_dir.path());
         let mut config = expired_refreshable_config();
-        config.platform_url = Some(server.url());
+        config.set_test_platform(&server.url());
         config.write_to_file(&cli_args).unwrap();
 
         let outcome = refresh_stored_auth(
@@ -2107,7 +2150,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let cli_args = test_cli_args(temp_dir.path());
         let mut config = expired_refreshable_config();
-        config.platform_url = Some(server.url());
+        config.set_test_platform(&server.url());
         config.write_to_file(&cli_args).unwrap();
 
         let error = refresh_stored_auth(
@@ -2152,7 +2195,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let cli_args = test_cli_args(temp_dir.path());
         let mut config = expired_refreshable_config();
-        config.platform_url = Some(server.url());
+        config.set_test_platform(&server.url());
         config.write_to_file(&cli_args).unwrap();
 
         let error = refresh_stored_auth(
@@ -2320,7 +2363,7 @@ mod tests {
         let auth_url = server.url();
         // The credentials belong to the mock platform, so the remote logout
         // may send the token there.
-        config.platform_url = Some(auth_url.clone());
+        config.set_test_platform(&auth_url);
         let cmd =
             AuthCommand::try_parse_from(vec!["auth", "--auth-url", auth_url.as_str(), "logout"])
                 .unwrap();
@@ -2471,8 +2514,19 @@ mod tests {
         assert!(base_cmd(Some("https://linea.phylax.systems")).switching_platform(&config));
         assert!(base_cmd(Some("https://custom.phylax.example")).switching_platform(&config));
 
-        // Explicit URL matching the credential platform does not switch.
+        // Rewriting only the *remembered* platform must not launder the
+        // credentials: that is the field startup overwrites from `-u` before
+        // the login runs, so trusting it here would compare the target against
+        // itself and short-circuit the switch.
         config.platform_url = Some("https://custom.phylax.example".to_string());
+        assert!(
+            base_cmd(Some("https://custom.phylax.example/")).switching_platform(&config),
+            "a remembered platform is not evidence of who issued the token"
+        );
+
+        // Explicit URL matching the platform that actually issued the
+        // credentials does not switch.
+        config.set_test_platform("https://custom.phylax.example");
         assert!(!base_cmd(Some("https://custom.phylax.example/")).switching_platform(&config));
 
         // Explicit URL for any other platform switches.
@@ -2486,7 +2540,7 @@ mod tests {
         );
         assert!(base_cmd(None).switching_platform(&config));
 
-        config.platform_url = Some("https://linea.phylax.systems".to_string());
+        config.set_test_platform("https://linea.phylax.systems");
         assert!(!base_cmd(None).switching_platform(&config));
     }
 
@@ -2500,7 +2554,15 @@ mod tests {
         let mut config = create_test_config();
         assert!(platform_switch(&resolved, &config));
 
+        // Selection state alone never satisfies the check — an interactive pick
+        // writes this field before the command runs.
         config.platform_url = Some("https://env-selected.phylax.example".to_string());
+        assert!(
+            platform_switch(&resolved, &config),
+            "a remembered platform must not stand in for credential provenance"
+        );
+
+        config.set_test_platform("https://env-selected.phylax.example");
         assert!(!platform_switch(&resolved, &config));
 
         // Without stored credentials there is no boundary to enforce.
@@ -2513,7 +2575,7 @@ mod tests {
         // deliberately not remembered, so these credentials carry no platform.
         // Trusting them against a freshly selected network would send a token
         // to a platform that did not issue it.
-        let config = create_test_config();
+        let mut config = create_test_config();
         assert!(config.platform_url.is_none());
         assert!(config.auth.is_some());
 
@@ -2528,6 +2590,18 @@ mod tests {
                 "unrecorded credentials must not be trusted against {target}"
             );
         }
+
+        // And still after an interactive selection has recorded that network.
+        // Selecting a platform is not logging into it, so the re-login this
+        // upgrade path promises has to survive the selection being remembered.
+        config.platform_url = Some("https://linea.phylax.systems".to_string());
+        assert!(
+            platform_switch(
+                &"https://linea.phylax.systems".parse().expect("test URL"),
+                &config
+            ),
+            "a selection must not re-bind credentials it did not issue"
+        );
 
         let err = ensure_credential_platform(
             &config,
@@ -2593,11 +2667,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_when_already_authenticated() {
-        // The stored credentials must record the platform being logged into,
-        // or the platform-boundary check treats this as a switch and starts a
-        // real device-auth flow instead of short-circuiting.
+        // The stored credentials must record the platform being logged into as
+        // their *issuer*, or the platform-boundary check treats this as a
+        // switch and starts a real device-auth flow instead of
+        // short-circuiting.
         let mut config = create_test_config();
-        config.platform_url = Some("https://linea.phylax.systems".to_string());
+        config.set_test_platform("https://linea.phylax.systems");
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
             "--auth-url",

--- a/crates/pcl/core/src/auth.rs
+++ b/crates/pcl/core/src/auth.rs
@@ -1,5 +1,4 @@
 use crate::{
-    DEFAULT_PLATFORM_URL,
     api::{
         envelope_output_string,
         generated_operation_path,
@@ -225,26 +224,70 @@ impl AuthCommand {
         )
     }
 
-    fn effective_auth_url(&self) -> url::Url {
-        if let Some(auth_url) = &self.auth_url {
-            return auth_url.clone();
-        }
-        if let Ok(api_url) = std::env::var("PCL_API_URL")
-            && let Ok(parsed) = api_url.parse()
-        {
-            return parsed;
-        }
-        crate::config::default_platform_url()
-            .parse()
-            .expect("default platform URL is valid")
+    /// Only a login records the platform it targeted. `ensure`, `refresh`, and
+    /// `status` must not move the remembered platform, and `logout` clears it.
+    pub fn persists_platform_url(&self) -> bool {
+        matches!(self.command, AuthSubcommands::Login { .. })
     }
 
-    /// Remembers a custom login URL in the config so later commands default to
-    /// it, or clears the remembered URL when logging in against production.
+    /// The platform this subcommand talks to.
+    ///
+    /// Only reached by subcommands that need one, all of which get a platform
+    /// resolved at startup — see [`Self::needs_platform_url`].
+    fn effective_auth_url(&self) -> url::Url {
+        self.reportable_auth_url()
+            .expect("startup resolves a platform for every auth subcommand that needs one")
+    }
+
+    /// The explicitly requested platform: `--auth-url`/`PCL_AUTH_URL` (both
+    /// land in `auth_url`), then `PCL_API_URL`.
+    ///
+    /// Startup consults this to skip platform resolution, so the `PCL_API_URL`
+    /// fallback has to live here rather than only in the resolved lookup —
+    /// otherwise a run with only `PCL_API_URL` set would still prompt.
+    pub fn platform_url_flag(&self) -> Option<url::Url> {
+        if let Some(auth_url) = &self.auth_url {
+            return Some(auth_url.clone());
+        }
+        std::env::var("PCL_API_URL")
+            .ok()
+            .and_then(|api_url| api_url.parse().ok())
+    }
+
+    /// The platform for reporting, which may not exist yet.
+    ///
+    /// `pcl auth status` and `pcl auth logout --local` answer questions about
+    /// local credentials and must work before any platform has been chosen.
+    fn reportable_auth_url(&self) -> Option<url::Url> {
+        self.platform_url_flag()
+            .or_else(crate::platform::active_platform_opt)
+    }
+
+    /// Reported platform, or a marker when none has been chosen yet.
+    fn reported_platform_url(&self) -> Value {
+        self.reportable_auth_url()
+            .map_or(Value::Null, |url| json!(url.as_str()))
+    }
+
+    /// Whether this subcommand reaches the platform and therefore needs one
+    /// resolved before it runs. `status` reads only local config, and
+    /// `logout --local` deliberately skips the remote call.
+    pub fn needs_platform_url(&self) -> bool {
+        !matches!(
+            self.command,
+            AuthSubcommands::Status | AuthSubcommands::Logout { local: true }
+        )
+    }
+
+    /// Remembers the platform this login targeted so later commands resolve to
+    /// it without prompting.
+    ///
+    /// Every login records its platform explicitly — there is no production
+    /// default whose absence could stand in for one.
     fn remember_platform_url(&self, config: &mut CliConfig) {
-        let auth_url = self.effective_auth_url();
-        config.platform_url = (auth_url.as_str().trim_end_matches('/') != DEFAULT_PLATFORM_URL)
-            .then(|| auth_url.as_str().trim_end_matches('/').to_string());
+        config.platform_url = Some(crate::platform::trim_platform_url(
+            &self.effective_auth_url(),
+        ));
     }
 
     /// Returns true when the *resolved* auth URL (explicit flag, then
@@ -297,7 +340,7 @@ impl AuthCommand {
                         "status": "ok",
                         "data": {
                             "authenticated": false,
-                            "platform_url": self.effective_auth_url().as_str(),
+                            "platform_url": self.reported_platform_url(),
                             "local_credentials_removed": true,
                             "remote_logout": logout,
                         },
@@ -937,7 +980,7 @@ impl AuthCommand {
                 "success": null,
                 "mode": "local",
                 "reason": "platform_mismatch",
-                "credential_platform": credential_platform(config),
+                "credential_platform": credential_platform_label(config),
                 "requested_platform": self.effective_auth_url().as_str(),
             });
         }
@@ -1031,7 +1074,10 @@ impl AuthCommand {
             return Err(AuthError::StoredTokenExpired {
                 user: auth.display_name(),
                 expires_at: auth.expires_at,
-                platform_url: self.effective_auth_url().as_str().to_string(),
+                platform_url: self.reportable_auth_url().map_or_else(
+                    || "no platform selected".to_string(),
+                    |url| crate::platform::trim_platform_url(&url),
+                ),
             });
         }
 
@@ -1054,7 +1100,7 @@ impl AuthCommand {
                     "expired": false,
                     "seconds_remaining": null,
                     "expires_in_seconds": null,
-                    "platform_url": self.effective_auth_url().as_str(),
+                    "platform_url": self.reported_platform_url(),
                 },
                 "next_actions": ["pcl auth login"],
             }));
@@ -1086,7 +1132,7 @@ impl AuthCommand {
                 "expires_at": auth.expires_at.to_rfc3339(),
                 "seconds_remaining": seconds_remaining,
                 "expires_in_seconds": seconds_remaining,
-                "platform_url": self.effective_auth_url().as_str(),
+                "platform_url": self.reported_platform_url(),
             },
             "next_actions": if token_expired {
                 json!(["pcl auth refresh --json", "pcl auth login --force", "pcl auth logout"])
@@ -1117,13 +1163,22 @@ impl AuthCommand {
     }
 }
 
-/// The platform the stored credentials were issued by: the remembered custom
-/// platform, or production when none is recorded.
-fn credential_platform(config: &CliConfig) -> &str {
-    config
-        .platform_url
-        .as_deref()
-        .unwrap_or(DEFAULT_PLATFORM_URL)
+/// The platform the stored credentials were issued by, when one is recorded.
+///
+/// Credentials stored by an earlier `pcl` — which deliberately left the
+/// remembered platform empty for production logins — have no recorded
+/// platform. There is no longer a default to assume them into, so they belong
+/// to an unknown platform.
+fn credential_platform(config: &CliConfig) -> Option<&str> {
+    config.platform_url.as_deref()
+}
+
+/// Label for the credential platform in operator-facing output.
+fn credential_platform_label(config: &CliConfig) -> String {
+    credential_platform(config).map_or_else(
+        || "an unrecorded platform (logged in with an earlier pcl release)".to_string(),
+        ToString::to_string,
+    )
 }
 
 /// Core of the platform-boundary check (split from
@@ -1136,7 +1191,14 @@ fn platform_switch(resolved: &url::Url, config: &CliConfig) -> bool {
     if config.auth.is_none() {
         return false;
     }
-    resolved.as_str().trim_end_matches('/') != credential_platform(config).trim_end_matches('/')
+    let Some(credential_platform) = credential_platform(config) else {
+        // Credentials from an earlier release record no platform. Treating
+        // them as belonging to whatever the user just selected would send a
+        // token to a platform that did not issue it, so this counts as a
+        // switch and forces a one-time re-login.
+        return true;
+    };
+    resolved.as_str().trim_end_matches('/') != credential_platform.trim_end_matches('/')
 }
 
 /// Guard for any code about to attach stored credentials to — or refresh
@@ -1148,7 +1210,7 @@ pub fn ensure_credential_platform(config: &CliConfig, target: &url::Url) -> Resu
         return Ok(());
     }
     Err(AuthError::PlatformMismatch {
-        credential_platform: credential_platform(config).to_string(),
+        credential_platform: credential_platform_label(config),
         requested: target.as_str().trim_end_matches('/').to_string(),
     })
 }
@@ -1682,31 +1744,60 @@ mod tests {
     }
 
     #[test]
-    fn remember_platform_url_stores_custom_url_and_clears_default() {
-        let mut config = CliConfig::default();
-
-        let cmd = AuthCommand {
-            command: AuthSubcommands::Login {
-                force: false,
-                no_wait: false,
-            },
-            auth_url: Some("https://custom.phylax.example/".parse().unwrap()),
+    fn remember_platform_url_always_stores_the_login_platform() {
+        // With no production default there is no sentinel: every login records
+        // its platform explicitly, including the production networks, so a
+        // later command never has to guess.
+        let login_against = |url: &str| {
+            let mut config = CliConfig::default();
+            AuthCommand {
+                command: AuthSubcommands::Login {
+                    force: false,
+                    no_wait: false,
+                },
+                auth_url: Some(url.parse().expect("test URL parses")),
+            }
+            .remember_platform_url(&mut config);
+            config.platform_url
         };
-        cmd.remember_platform_url(&mut config);
+
         assert_eq!(
-            config.platform_url.as_deref(),
+            login_against("https://custom.phylax.example/").as_deref(),
             Some("https://custom.phylax.example")
         );
+        assert_eq!(
+            login_against("https://linea.phylax.systems").as_deref(),
+            Some("https://linea.phylax.systems")
+        );
+        assert_eq!(
+            login_against("https://ethereum.phylax.systems/").as_deref(),
+            Some("https://ethereum.phylax.systems")
+        );
+    }
 
-        let cmd = AuthCommand {
-            command: AuthSubcommands::Login {
-                force: false,
-                no_wait: false,
-            },
-            auth_url: Some(DEFAULT_PLATFORM_URL.parse().unwrap()),
+    #[test]
+    fn only_login_persists_the_platform() {
+        let subcommand_persists = |command: AuthSubcommands| {
+            AuthCommand {
+                command,
+                auth_url: None,
+            }
+            .persists_platform_url()
         };
-        cmd.remember_platform_url(&mut config);
-        assert!(config.platform_url.is_none());
+
+        assert!(subcommand_persists(AuthSubcommands::Login {
+            force: false,
+            no_wait: false,
+        }));
+        assert!(!subcommand_persists(AuthSubcommands::Refresh {
+            force: false
+        }));
+        assert!(!subcommand_persists(AuthSubcommands::Ensure {
+            force: false
+        }));
+        assert!(!subcommand_persists(AuthSubcommands::Logout {
+            local: false
+        }));
     }
 
     #[test]
@@ -1721,7 +1812,7 @@ mod tests {
             }
         };
 
-        let production = login(DEFAULT_PLATFORM_URL);
+        let production = login("https://app.phylax.systems");
         let notice = production.v2_spec_notice().expect("notice on production");
         assert!(notice.contains("V1 assertion spec"), "{notice}");
 
@@ -2263,7 +2354,10 @@ mod tests {
         assert_eq!(logout["attempted"], false);
         assert_eq!(logout["mode"], "local");
         assert_eq!(logout["reason"], "platform_mismatch");
-        assert_eq!(logout["credential_platform"], DEFAULT_PLATFORM_URL);
+        assert_eq!(
+            logout["credential_platform"],
+            "an unrecorded platform (logged in with an earlier pcl release)"
+        );
         mock.assert_async().await;
     }
 
@@ -2371,26 +2465,29 @@ mod tests {
 
         let mut config = create_test_config();
 
-        // No explicit URL resolves to the credential platform (production
-        // here, since unit-test builds never remember a platform).
-        assert!(!base_cmd(None).switching_platform(&config));
+        // Credentials stored by an earlier release record no platform. With no
+        // default to assume them into, any target counts as a switch and
+        // forces a one-time re-login.
+        assert!(base_cmd(Some("https://linea.phylax.systems")).switching_platform(&config));
+        assert!(base_cmd(Some("https://custom.phylax.example")).switching_platform(&config));
 
         // Explicit URL matching the credential platform does not switch.
         config.platform_url = Some("https://custom.phylax.example".to_string());
         assert!(!base_cmd(Some("https://custom.phylax.example/")).switching_platform(&config));
 
-        // Explicit URL for another platform (including back to production) switches.
+        // Explicit URL for any other platform switches.
         assert!(base_cmd(Some("https://other.phylax.example")).switching_platform(&config));
-        assert!(base_cmd(Some(DEFAULT_PLATFORM_URL)).switching_platform(&config));
+        assert!(base_cmd(Some("https://linea.phylax.systems")).switching_platform(&config));
 
-        // The check compares the *resolved* URL, so a default resolution that
-        // lands on production also switches away from custom credentials.
+        // With no explicit flag the resolved URL is the startup platform, so
+        // the boundary check follows that rather than a compiled-in default.
+        crate::platform::set_active_platform(
+            "https://linea.phylax.systems".parse().expect("test URL"),
+        );
         assert!(base_cmd(None).switching_platform(&config));
 
-        // Without a remembered platform, production is the current platform.
-        config.platform_url = None;
-        assert!(!base_cmd(Some(DEFAULT_PLATFORM_URL)).switching_platform(&config));
-        assert!(base_cmd(Some("https://custom.phylax.example")).switching_platform(&config));
+        config.platform_url = Some("https://linea.phylax.systems".to_string());
+        assert!(!base_cmd(None).switching_platform(&config));
     }
 
     #[test]
@@ -2410,6 +2507,39 @@ mod tests {
         assert!(!platform_switch(&resolved, &CliConfig::default()));
     }
 
+    #[test]
+    fn credentials_without_a_recorded_platform_always_count_as_switching() {
+        // The upgrade path: production logins under the old default were
+        // deliberately not remembered, so these credentials carry no platform.
+        // Trusting them against a freshly selected network would send a token
+        // to a platform that did not issue it.
+        let config = create_test_config();
+        assert!(config.platform_url.is_none());
+        assert!(config.auth.is_some());
+
+        for target in [
+            "https://linea.phylax.systems",
+            "https://ethereum.phylax.systems",
+            "https://app.phylax.systems",
+        ] {
+            let resolved: url::Url = target.parse().expect("test URL parses");
+            assert!(
+                platform_switch(&resolved, &config),
+                "unrecorded credentials must not be trusted against {target}"
+            );
+        }
+
+        let err = ensure_credential_platform(
+            &config,
+            &"https://linea.phylax.systems".parse().expect("test URL"),
+        )
+        .expect_err("unrecorded credentials are a platform mismatch");
+        assert!(
+            err.to_string().contains("earlier pcl release"),
+            "error should explain the upgrade path: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn login_with_explicit_custom_url_starts_fresh_login_despite_valid_token() {
         let mut server = Server::new_async().await;
@@ -2420,8 +2550,9 @@ mod tests {
             .with_body(test_auth_response_json())
             .create();
 
-        // Token is still valid, but it belongs to production, not the
-        // explicitly requested platform: login must not short-circuit.
+        // Token is still valid, but records no platform of its own, so it does
+        // not belong to the explicitly requested one: login must not
+        // short-circuit.
         let mut config = create_test_config();
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
@@ -2462,11 +2593,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_when_already_authenticated() {
+        // The stored credentials must record the platform being logged into,
+        // or the platform-boundary check treats this as a switch and starts a
+        // real device-auth flow instead of short-circuiting.
         let mut config = create_test_config();
+        config.platform_url = Some("https://linea.phylax.systems".to_string());
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
             "--auth-url",
-            "https://app.phylax.systems",
+            "https://linea.phylax.systems",
             "login",
         ])
         .unwrap();

--- a/crates/pcl/core/src/client.rs
+++ b/crates/pcl/core/src/client.rs
@@ -52,6 +52,18 @@ pub async fn ensure_fresh_auth(
     validate_auth(config).map(|_| ())
 }
 
+/// Base URL for API calls against `api_url`.
+///
+/// Always derived from the resolved platform URL rather than a compiled-in
+/// host. `dapp.phylax.systems` answers with a 301, and reqwest — like most HTTP
+/// clients — downgrades a redirected POST to GET, so routing writes through a
+/// redirect chain would silently drop request bodies.
+pub fn api_base_url(api_url: &url::Url) -> String {
+    let mut base = api_url.clone();
+    base.set_path("/api/v1");
+    base.to_string()
+}
+
 pub fn authenticated_client(
     config: &CliConfig,
     api_url: &url::Url,
@@ -59,9 +71,7 @@ pub fn authenticated_client(
     // Never attach the stored bearer token to a platform that did not issue it.
     crate::auth::ensure_credential_platform(config, api_url)
         .map_err(ClientBuildError::PlatformMismatch)?;
-    let mut base = api_url.clone();
-    base.set_path("/api/v1");
-    let base_url = base.to_string();
+    let base_url = api_base_url(api_url);
 
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
@@ -104,6 +114,44 @@ mod tests {
     use super::*;
     use crate::config::UserAuth;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn api_base_url_follows_the_resolved_platform() {
+        for (platform, expected) in [
+            (
+                "https://linea.phylax.systems",
+                "https://linea.phylax.systems/api/v1",
+            ),
+            (
+                "https://ethereum.phylax.systems/",
+                "https://ethereum.phylax.systems/api/v1",
+            ),
+            (
+                "https://shadow.phylax.example",
+                "https://shadow.phylax.example/api/v1",
+            ),
+            ("http://localhost:3000", "http://localhost:3000/api/v1"),
+        ] {
+            let resolved: url::Url = platform.parse().expect("test URL parses");
+            assert_eq!(api_base_url(&resolved), expected);
+        }
+    }
+
+    #[test]
+    fn api_base_url_never_routes_through_the_redirecting_host() {
+        // `dapp.phylax.systems` 301s to the network selector, and a redirected
+        // POST is downgraded to GET — bodies would be dropped. Requests must
+        // go straight to the resolved platform.
+        for platform in [
+            "https://linea.phylax.systems",
+            "https://ethereum.phylax.systems",
+        ] {
+            let resolved: url::Url = platform.parse().expect("test URL parses");
+            let base = api_base_url(&resolved);
+            assert!(!base.contains("dapp.phylax.systems"), "{base}");
+            assert!(!base.contains("app.phylax.systems"), "{base}");
+        }
+    }
 
     #[tokio::test]
     async fn ensure_fresh_auth_refreshes_expired_token_before_header_use() {

--- a/crates/pcl/core/src/client.rs
+++ b/crates/pcl/core/src/client.rs
@@ -176,6 +176,7 @@ mod tests {
         let mut config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: Some(server.url()),
                 access_token: "expired-token".to_string(),
                 refresh_token: "old-refresh".to_string(),
                 expires_at: DateTime::from_timestamp(1, 0).expect("valid timestamp"),
@@ -217,6 +218,7 @@ mod tests {
         // mock platform.
         let mut config = CliConfig {
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "expired-token".to_string(),
                 refresh_token: "old-refresh".to_string(),
                 expires_at: DateTime::from_timestamp(1, 0).expect("valid timestamp"),
@@ -244,6 +246,7 @@ mod tests {
         // Valid production credentials must not be attached to another host.
         let config = CliConfig {
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "valid-token".to_string(),
                 refresh_token: "refresh".to_string(),
                 expires_at: DateTime::from_timestamp(4_102_444_800, 0).expect("valid timestamp"),
@@ -267,6 +270,7 @@ mod tests {
         let config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "expired-token".to_string(),
                 refresh_token: String::new(),
                 expires_at: DateTime::from_timestamp(1, 0).expect("valid timestamp"),

--- a/crates/pcl/core/src/config.rs
+++ b/crates/pcl/core/src/config.rs
@@ -1,5 +1,4 @@
 use crate::{
-    DEFAULT_PLATFORM_URL,
     api::{
         envelope_output_string,
         with_envelope_metadata,
@@ -36,7 +35,6 @@ use std::{
         Path,
         PathBuf,
     },
-    sync::OnceLock,
 };
 use uuid::Uuid;
 
@@ -56,11 +54,14 @@ pub const AUTH_EXPIRES_SOON_SECONDS: i64 = 300;
 pub struct CliConfig {
     /// Optional authentication details
     pub auth: Option<UserAuth>,
-    /// Platform URL remembered from `pcl auth login --auth-url <url>`.
+    /// Platform URL remembered from the last `pcl auth login` or interactive
+    /// network selection.
     ///
-    /// Only set when the login URL differs from the production default, and
-    /// cleared on `pcl auth logout`. Used as the default for `--api-url` and
-    /// `--auth-url` so a custom platform only has to be specified once.
+    /// Always set explicitly once a platform has been chosen — there is no
+    /// production default to encode as an absent value — and cleared on
+    /// `pcl auth logout`. Resolution reads this after an explicit
+    /// `-u`/`PCL_API_URL` and before prompting, so a platform only has to be
+    /// chosen once.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub platform_url: Option<String>,
     /// Per-chain RPC endpoints used when broadcasting transactions.
@@ -519,59 +520,6 @@ impl CliConfig {
                 .unwrap_or(Self::get_config_dir()),
         )
     }
-}
-
-/// Returns the platform URL remembered from the last `pcl auth login` against
-/// a custom platform, if any.
-///
-/// The value is read once per process from the config file on disk (honoring
-/// `--config-dir` from the process arguments) so it can be used as a clap
-/// `default_value` before the config is otherwise loaded. Unit-test builds
-/// always return `None` to keep parsing deterministic.
-pub fn remembered_platform_url() -> Option<&'static str> {
-    static REMEMBERED: OnceLock<Option<String>> = OnceLock::new();
-    REMEMBERED
-        .get_or_init(|| {
-            if cfg!(test) {
-                return None;
-            }
-            let config_dir =
-                config_dir_from_process_args().unwrap_or_else(CliConfig::get_config_dir);
-            CliConfig::read_from_file_at_dir(&config_dir)
-                .ok()?
-                .platform_url
-                .filter(|url| url.parse::<url::Url>().is_ok())
-        })
-        .as_deref()
-}
-
-/// Default platform URL for `--api-url`/`--auth-url` arguments: the URL
-/// remembered from the last `pcl auth login`, falling back to production.
-pub fn default_platform_url() -> &'static str {
-    remembered_platform_url().unwrap_or(DEFAULT_PLATFORM_URL)
-}
-
-/// Extracts `--config-dir <path>` (or `--config-dir=<path>`) from the process
-/// arguments without a full clap parse.
-fn config_dir_from_process_args() -> Option<PathBuf> {
-    config_dir_from_args(std::env::args_os().skip(1))
-}
-
-fn config_dir_from_args<I>(args: I) -> Option<PathBuf>
-where
-    I: IntoIterator<Item = std::ffi::OsString>,
-{
-    let mut iter = args.into_iter();
-    while let Some(arg) = iter.next() {
-        let value = arg.to_string_lossy();
-        if value == "--config-dir" {
-            return iter.next().map(PathBuf::from);
-        }
-        if let Some(path) = value.strip_prefix("--config-dir=") {
-            return Some(PathBuf::from(path.to_string()));
-        }
-    }
-    None
 }
 
 fn config_show_envelope(config: &CliConfig, cli_args: &CliArgs) -> Value {
@@ -1175,31 +1123,6 @@ expires_at = 1672502400
 
         let config = CliConfig::read_from_file_at_dir(&config_dir).unwrap();
         assert!(config.platform_url.is_none());
-    }
-
-    #[test]
-    fn extracts_config_dir_from_args() {
-        use std::ffi::OsString;
-
-        let args = ["--json", "--config-dir", "/tmp/pcl-conf", "auth"].map(OsString::from);
-        assert_eq!(
-            config_dir_from_args(args),
-            Some(PathBuf::from("/tmp/pcl-conf"))
-        );
-
-        let args = ["auth", "--config-dir=/tmp/pcl-conf2"].map(OsString::from);
-        assert_eq!(
-            config_dir_from_args(args),
-            Some(PathBuf::from("/tmp/pcl-conf2"))
-        );
-
-        let args = ["auth", "login"].map(OsString::from);
-        assert_eq!(config_dir_from_args(args), None);
-    }
-
-    #[test]
-    fn default_platform_url_falls_back_to_production_in_tests() {
-        assert_eq!(default_platform_url(), DEFAULT_PLATFORM_URL);
     }
 
     #[test]

--- a/crates/pcl/core/src/config.rs
+++ b/crates/pcl/core/src/config.rs
@@ -30,11 +30,17 @@ use serde_json::{
 use std::{
     collections::BTreeMap,
     fmt,
+    fs::OpenOptions,
     io::Write,
     path::{
         Path,
         PathBuf,
     },
+};
+use tokio::time::{
+    Duration,
+    Instant,
+    sleep,
 };
 use uuid::Uuid;
 
@@ -45,6 +51,73 @@ const CONFIG_DIR_NAME: &str = "pcl";
 /// Configuration file name
 pub const CONFIG_FILE: &str = "config.toml";
 pub const AUTH_EXPIRES_SOON_SECONDS: i64 = 300;
+
+/// How long to wait for another process to release the config lock.
+const CONFIG_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+/// How often to retry while the config lock is held.
+const CONFIG_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Cross-process guard over the config file, held for a whole
+/// read-modify-write.
+///
+/// Compare-and-write ([`CliConfig::write_to_file_if_unchanged`]) is not enough
+/// on its own: it narrows the window between reading and writing but cannot
+/// close it, so two processes can still interleave and the loser's write is
+/// simply dropped. That is tolerable for a passive rewrite, and *not* tolerable
+/// for the refresh token — there is only ever one valid refresh token, so
+/// losing the write that recorded it logs the user out.
+///
+/// So every writer that merges into whatever is currently on disk takes this
+/// lock, and they all take the *same* one: token refresh and platform selection
+/// are different operations on the same file, and a lock that only refresh
+/// honoured would not serialize them against each other.
+///
+/// Released on drop, including on panic. A stale file left by a killed process
+/// does not wedge the CLI forever: waiting gives up after 30 seconds and
+/// surfaces [`ConfigError::LockTimeout`] instead.
+#[derive(Debug)]
+pub struct ConfigLock {
+    path: PathBuf,
+}
+
+impl ConfigLock {
+    /// Acquires the lock, waiting up to 30 seconds for another process to
+    /// release it before returning [`ConfigError::LockTimeout`].
+    pub async fn acquire(cli_args: &CliArgs) -> Result<Self, ConfigError> {
+        let path = CliConfig::config_file_path(cli_args).with_extension("toml.lock");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(ConfigError::WriteError)?;
+        }
+        let deadline = Instant::now() + CONFIG_LOCK_TIMEOUT;
+        loop {
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(mut file) => {
+                    let _ = writeln!(
+                        file,
+                        "pid={} acquired_at={}",
+                        std::process::id(),
+                        Utc::now().to_rfc3339()
+                    );
+                    let _ = file.sync_all();
+                    return Ok(Self { path });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if Instant::now() >= deadline {
+                        return Err(ConfigError::LockTimeout);
+                    }
+                    sleep(CONFIG_LOCK_POLL_INTERVAL).await;
+                }
+                Err(error) => return Err(ConfigError::WriteError(error)),
+            }
+        }
+    }
+}
+
+impl Drop for ConfigLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
 
 /// Main configuration structure for PCL
 ///
@@ -282,6 +355,37 @@ impl CliConfig {
                 .clone()
                 .unwrap_or(Self::get_config_dir()),
         )
+    }
+
+    /// Records this process's chosen platform without clobbering a concurrent
+    /// write, then adopts whatever ended up on disk.
+    ///
+    /// The in-memory config was read before the network selector prompted, and
+    /// the prompt stays open for as long as the user takes to answer. Another
+    /// `pcl` can rotate the refresh token in that window, so this process's
+    /// snapshot must not be written wholesale — only `platform_url` is merged
+    /// into the current file.
+    ///
+    /// The read and the write are both inside a [`ConfigLock`] because merging
+    /// is only safe if nothing else writes in between: a token refresh landing
+    /// after the read would be overwritten by the write, discarding the only
+    /// valid refresh token. Holding the same lock refresh takes makes the two
+    /// operations mutually exclusive rather than merely narrow.
+    pub async fn merge_selected_platform(&mut self, cli_args: &CliArgs) -> Result<(), ConfigError> {
+        let _lock = ConfigLock::acquire(cli_args).await?;
+        let Ok(mut current) = Self::read_from_file(cli_args) else {
+            // Unreadable only if it changed under us since startup, where the
+            // caller already parsed it. Nothing to merge, so record the choice.
+            return self.write_to_file(cli_args);
+        };
+        if current == *self {
+            return Ok(());
+        }
+        current.normalize_auth_expiry_from_access_token();
+        current.platform_url.clone_from(&self.platform_url);
+        current.write_to_file(cli_args)?;
+        *self = current;
+        Ok(())
     }
 
     /// Writes the configuration only when the on-disk config still matches
@@ -1008,6 +1112,161 @@ expires_at = 1672502400
             "https://mainnet.infura.io"
         );
         assert_eq!(redacted_rpc_host("not a url"), "<unparseable-url>");
+    }
+
+    /// A config carrying credentials, as another process would have left it.
+    fn authenticated_config(access: &str, refresh: &str) -> CliConfig {
+        CliConfig {
+            auth: Some(UserAuth {
+                access_token: access.to_string(),
+                refresh_token: refresh.to_string(),
+                expires_at: DateTime::from_timestamp(4_102_444_800, 0).expect("timestamp"),
+                refresh_expires_at: None,
+                user_id: None,
+                wallet_address: None,
+                email: None,
+                issuer_platform_url: Some("https://linea.phylax.systems".to_string()),
+            }),
+            ..CliConfig::default()
+        }
+    }
+
+    /// Recording a selected platform must not roll back an update that landed
+    /// before the merge started.
+    ///
+    /// The interactive selector can sit open indefinitely, and another `pcl` may
+    /// rotate the refresh token while it does. Writing this process's pre-prompt
+    /// snapshot would discard the rotation and leave a refresh token the
+    /// platform has already invalidated.
+    #[tokio::test]
+    async fn merging_a_selected_platform_keeps_an_already_rotated_token() {
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let cli_args = CliArgs {
+            config_dir: Some(config_dir.path().to_path_buf()),
+            ..CliArgs::default()
+        };
+
+        let stale = authenticated_config("old-access", "old-refresh");
+        authenticated_config("rotated-access", "rotated-refresh")
+            .write_to_file(&cli_args)
+            .expect("another process writes the rotated pair");
+
+        let mut config = stale.clone();
+        config.platform_url = Some("https://ethereum.phylax.systems".to_string());
+        config
+            .merge_selected_platform(&cli_args)
+            .await
+            .expect("merge the selection");
+
+        let on_disk = CliConfig::read_from_file(&cli_args).expect("read merged config");
+        let auth = on_disk.auth.as_ref().expect("credentials survive");
+        assert_eq!(
+            auth.refresh_token, "rotated-refresh",
+            "the concurrently rotated refresh token must survive"
+        );
+        assert_eq!(auth.access_token, "rotated-access");
+        assert_eq!(
+            on_disk.platform_url.as_deref(),
+            Some("https://ethereum.phylax.systems"),
+            "the selection still has to be recorded"
+        );
+        assert_eq!(
+            config, on_disk,
+            "this process adopts the merged state for the rest of the run"
+        );
+    }
+
+    /// The rotation that overlaps the merge is the dangerous one.
+    ///
+    /// Reloading before the write only protects updates that finished before the
+    /// reload. Without a lock, a refresh that writes its new pair *after* the
+    /// reload and before the merge's own write is silently overwritten, throwing
+    /// away the only valid refresh token — and the sibling test above cannot
+    /// catch it, because there the rotation is already on disk when the merge
+    /// begins.
+    ///
+    /// The lock itself is the barrier here: holding it forces the merge to wait,
+    /// and the rotation is written while it waits, so the rotation lands strictly
+    /// between the merge being asked for and the merge reading the file.
+    #[tokio::test]
+    async fn merging_a_selected_platform_waits_for_an_overlapping_rotation() {
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let cli_args = CliArgs {
+            config_dir: Some(config_dir.path().to_path_buf()),
+            ..CliArgs::default()
+        };
+
+        let stale = authenticated_config("old-access", "old-refresh");
+        stale
+            .write_to_file(&cli_args)
+            .expect("the pre-prompt state is on disk");
+
+        // Stand in for a concurrent `refresh_stored_auth`, which holds this same
+        // lock across its own read-modify-write.
+        let lock = ConfigLock::acquire(&cli_args)
+            .await
+            .expect("the refresher takes the lock first");
+
+        let mut config = stale.clone();
+        config.platform_url = Some("https://ethereum.phylax.systems".to_string());
+        let merge_args = cli_args.clone();
+        let merge = tokio::spawn(async move {
+            config.merge_selected_platform(&merge_args).await?;
+            Ok::<CliConfig, ConfigError>(config)
+        });
+
+        // The merge cannot have read anything yet: it is parked on the lock.
+        tokio::time::sleep(CONFIG_LOCK_POLL_INTERVAL * 3).await;
+        assert!(
+            !merge.is_finished(),
+            "the merge must block until the refresher releases the lock"
+        );
+        authenticated_config("rotated-access", "rotated-refresh")
+            .write_to_file(&cli_args)
+            .expect("the refresher writes its rotated pair");
+        drop(lock);
+
+        let merged = merge
+            .await
+            .expect("merge task joins")
+            .expect("merge the selection");
+
+        let on_disk = CliConfig::read_from_file(&cli_args).expect("read merged config");
+        let auth = on_disk.auth.as_ref().expect("credentials survive");
+        assert_eq!(
+            auth.refresh_token, "rotated-refresh",
+            "a rotation overlapping the merge must survive it"
+        );
+        assert_eq!(auth.access_token, "rotated-access");
+        assert_eq!(
+            on_disk.platform_url.as_deref(),
+            Some("https://ethereum.phylax.systems"),
+            "the selection still has to be recorded"
+        );
+        assert_eq!(merged, on_disk);
+    }
+
+    /// A lock left behind by a killed process must not wedge the CLI forever.
+    ///
+    /// Runs on a paused clock, which tokio auto-advances whenever every task is
+    /// parked on a timer, so the whole `CONFIG_LOCK_TIMEOUT` budget elapses
+    /// instantly instead of costing the suite 30 real seconds.
+    #[tokio::test(start_paused = true)]
+    async fn a_held_config_lock_times_out_rather_than_blocking_forever() {
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let cli_args = CliArgs {
+            config_dir: Some(config_dir.path().to_path_buf()),
+            ..CliArgs::default()
+        };
+        let _held = ConfigLock::acquire(&cli_args).await.expect("first acquire");
+
+        let error = ConfigLock::acquire(&cli_args)
+            .await
+            .expect_err("the lock is still held, so acquiring must fail");
+        assert!(
+            matches!(error, ConfigError::LockTimeout),
+            "expected a lock timeout, got {error:?}"
+        );
     }
 
     #[test]

--- a/crates/pcl/core/src/config.rs
+++ b/crates/pcl/core/src/config.rs
@@ -85,6 +85,21 @@ impl CliConfig {
     pub fn rpc_endpoint(&self, chain_id: u64) -> Option<&RpcEndpoint> {
         self.rpc.get(&chain_id.to_string())
     }
+
+    /// Records `platform_url` as both the remembered platform and the issuer of
+    /// the stored credentials — the state a completed login leaves behind.
+    ///
+    /// Test-only, and deliberately one call: a fixture that sets only the
+    /// remembered platform describes credentials of unknown provenance, which
+    /// the platform-boundary check refuses. Tests that mean *that* state set
+    /// `platform_url` on its own.
+    #[cfg(test)]
+    pub(crate) fn set_test_platform(&mut self, platform_url: &str) {
+        self.platform_url = Some(platform_url.to_string());
+        if let Some(auth) = &mut self.auth {
+            auth.issuer_platform_url = Some(platform_url.to_string());
+        }
+    }
 }
 
 /// Command-line arguments for configuration management
@@ -283,6 +298,27 @@ impl CliConfig {
         }
         self.write_to_file(cli_args)?;
         Ok(true)
+    }
+
+    /// Copies an unreadable config file aside before it is replaced.
+    ///
+    /// A repair command (`pcl auth login`, `pcl config delete`) is allowed to
+    /// write a fresh config over a file it could not parse. Those bytes may
+    /// still hold recoverable credentials or RPC settings, so they are kept at
+    /// `config.toml.invalid` rather than dropped. Returns the backup path, or
+    /// `None` when there was no file to preserve.
+    ///
+    /// Only ever reached while the current file is unparseable, so it cannot
+    /// overwrite a backup taken from a good config: once the repair succeeds the
+    /// file parses and this is not called again.
+    pub fn back_up_unreadable(cli_args: &CliArgs) -> Result<Option<PathBuf>, ConfigError> {
+        let source = Self::config_file_path(cli_args);
+        if !source.exists() {
+            return Ok(None);
+        }
+        let backup = source.with_extension("toml.invalid");
+        std::fs::copy(&source, &backup).map_err(ConfigError::WriteError)?;
+        Ok(Some(backup))
     }
 
     /// Writes the configuration to a specific directory
@@ -686,6 +722,22 @@ pub struct UserAuth {
     /// Email address of the user (for email-based auth)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+    /// The platform that issued these credentials.
+    ///
+    /// Deliberately stored *with* the credentials rather than alongside the
+    /// remembered platform in [`CliConfig::platform_url`]. The two answer
+    /// different questions — "which platform did I choose?" versus "who issued
+    /// this token?" — and only the second may gate attaching the token to a
+    /// request. Keeping provenance here makes that separation structural: it is
+    /// written only when fresh credentials are stored, cleared with them on
+    /// logout, and cannot be rebound by platform resolution or an interactive
+    /// selection.
+    ///
+    /// `None` for credentials stored by a release that did not record it. There
+    /// is no default to assume those into, so they belong to an unknown
+    /// platform and force a one-time re-login.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer_platform_url: Option<String>,
 }
 
 impl UserAuth {
@@ -821,6 +873,7 @@ mod tests {
         let config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "test_access".to_string(),
                 refresh_token: "test_refresh".to_string(),
                 expires_at: fixed_timestamp,
@@ -1040,6 +1093,7 @@ expires_at = 1672502400
         let old_config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "old_access".to_string(),
                 refresh_token: "old_refresh".to_string(),
                 expires_at: DateTime::from_timestamp(1672502400, 0).unwrap(),
@@ -1053,6 +1107,7 @@ expires_at = 1672502400
         let stale_process_config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "normalized_old_access".to_string(),
                 refresh_token: "old_refresh".to_string(),
                 expires_at: DateTime::from_timestamp(4102444800, 0).unwrap(),
@@ -1066,6 +1121,7 @@ expires_at = 1672502400
         let newer_config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "new_access".to_string(),
                 refresh_token: "new_refresh".to_string(),
                 expires_at: DateTime::from_timestamp(4102444800, 0).unwrap(),
@@ -1137,6 +1193,7 @@ expires_at = 1672502400
     #[test]
     fn test_user_auth_display() {
         let auth = UserAuth {
+            issuer_platform_url: None,
             access_token: "test_access".to_string(),
             refresh_token: "test_refresh".to_string(),
             expires_at: DateTime::from_timestamp(1672502400, 0).unwrap(), // 2022-12-31 16:00:00 UTC
@@ -1159,6 +1216,7 @@ expires_at = 1672502400
 
         // Non-zero wallet address takes priority over everything
         let with_addr = UserAuth {
+            issuer_platform_url: None,
             access_token: String::new(),
             refresh_token: String::new(),
             expires_at: expires,
@@ -1174,6 +1232,7 @@ expires_at = 1672502400
 
         // Email is next priority when no wallet address
         let with_email = UserAuth {
+            issuer_platform_url: None,
             access_token: String::new(),
             refresh_token: String::new(),
             expires_at: expires,
@@ -1186,6 +1245,7 @@ expires_at = 1672502400
 
         // User ID is fallback when no address or email
         let with_id = UserAuth {
+            issuer_platform_url: None,
             access_token: String::new(),
             refresh_token: String::new(),
             expires_at: expires,
@@ -1201,6 +1261,7 @@ expires_at = 1672502400
 
         // "unknown" when nothing is set
         let bare = UserAuth {
+            issuer_platform_url: None,
             access_token: String::new(),
             refresh_token: String::new(),
             expires_at: expires,
@@ -1215,6 +1276,7 @@ expires_at = 1672502400
     #[test]
     fn extracts_expiry_from_jwt_access_token() {
         let auth = UserAuth {
+            issuer_platform_url: None,
             access_token: "e30.eyJleHAiOjQxMDI0NDQ4MDB9.sig".to_string(),
             refresh_token: String::new(),
             expires_at: DateTime::from_timestamp(0, 0).unwrap(),
@@ -1235,6 +1297,7 @@ expires_at = 1672502400
         let mut config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "e30.eyJleHAiOjQxMDI0NDQ4MDB9.sig".to_string(),
                 refresh_token: "refresh".to_string(),
                 expires_at: DateTime::from_timestamp(1, 0).unwrap(),
@@ -1267,6 +1330,7 @@ expires_at = 1672502400
         let mut config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "test".to_string(),
                 refresh_token: "test".to_string(),
                 expires_at: DateTime::from_timestamp(1672502400, 0).unwrap(),
@@ -1293,6 +1357,7 @@ expires_at = 1672502400
         let config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "secret-access".to_string(),
                 refresh_token: "secret-refresh".to_string(),
                 expires_at: Utc::now() + chrono::Duration::minutes(10),
@@ -1365,6 +1430,7 @@ expires_at = 1672502400
     #[test]
     fn test_user_auth_serialization() {
         let auth = UserAuth {
+            issuer_platform_url: None,
             access_token: "test_access".to_string(),
             refresh_token: "test_refresh".to_string(),
             expires_at: DateTime::from_timestamp(1672502400, 0).unwrap(),

--- a/crates/pcl/core/src/deploy.rs
+++ b/crates/pcl/core/src/deploy.rs
@@ -860,6 +860,15 @@ impl DeployArgs {
         crate::platform::platform_url_or_active(self.api_url.as_ref())
     }
 
+    /// Whether this run reaches the platform.
+    ///
+    /// `--dry-run` builds and verifies locally and returns before any client is
+    /// constructed, so planning a deploy must not require choosing a network —
+    /// and must not prompt for one, since the flag promises to change nothing.
+    pub fn needs_platform_url(&self) -> bool {
+        !self.dry_run
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run(&self, cli_args: &CliArgs, config: &mut CliConfig) -> Result<(), DeployError> {
         let output_mode = cli_args.output_mode();
@@ -1309,11 +1318,12 @@ impl DeployArgs {
         let requested = crate::platform::trim_platform_url(&self.resolved_api_url());
         if intent.platform_url != requested {
             // The unresolved create belongs to another platform; matching
-            // this platform's projects against it proves nothing.
+            // this platform's projects against it proves nothing. The comparison
+            // is on the lossless form; only the message is redacted.
             return Err(DeployError::CreateIntentPlatformMismatch {
                 path: intent_path.display().to_string(),
-                intent_platform: intent.platform_url.clone(),
-                requested,
+                intent_platform: crate::platform::redact_stored_platform_url(&intent.platform_url),
+                requested: crate::platform::redact_platform_url(&self.resolved_api_url()),
             });
         }
         progress(
@@ -1462,8 +1472,14 @@ impl DeployArgs {
         chain_id: Option<u64>,
         findings: &[V2SpecFinding],
     ) -> Vec<Value> {
+        // A `--dry-run` may have no platform at all: it plans locally, so it must
+        // not require one. `chain_id` still decides on its own when it is known.
+        let platform_url = self
+            .api_url
+            .clone()
+            .or_else(crate::platform::active_platform_opt);
         let Some(message) =
-            assertion_spec::deploy_warning(&self.resolved_api_url(), chain_id, findings)
+            assertion_spec::deploy_warning(platform_url.as_ref(), chain_id, findings)
         else {
             return Vec::new();
         };
@@ -1472,7 +1488,7 @@ impl DeployArgs {
         }
         vec![assertion_spec::warning_json(
             &message,
-            &self.resolved_api_url(),
+            platform_url.as_ref(),
             chain_id,
             findings,
         )]
@@ -2377,6 +2393,7 @@ mod tests {
         let api = ApiArgs::headless(server.url().parse().unwrap());
         let mut config = CliConfig {
             auth: Some(crate::config::UserAuth {
+                issuer_platform_url: Some(server.url()),
                 access_token: "access-token".to_string(),
                 refresh_token: "refresh-token".to_string(),
                 expires_at: Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap(),

--- a/crates/pcl/core/src/deploy.rs
+++ b/crates/pcl/core/src/deploy.rs
@@ -105,10 +105,9 @@ pub struct DeployArgs {
         long = "api-url",
         env = "PCL_API_URL",
         value_hint = ValueHint::Url,
-        default_value = crate::config::default_platform_url(),
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login, then production"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    pub api_url: Url,
+    pub api_url: Option<Url>,
 
     #[command(flatten)]
     pub wallet: WalletArgs,
@@ -855,6 +854,12 @@ fn attach_warnings(source: DeployError, warnings: Vec<Value>) -> DeployError {
 }
 
 impl DeployArgs {
+    /// Platform URL for this run: the explicit `-u`/`PCL_API_URL` value when
+    /// given, otherwise the platform resolved during startup.
+    fn resolved_api_url(&self) -> Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run(&self, cli_args: &CliArgs, config: &mut CliConfig) -> Result<(), DeployError> {
         let output_mode = cli_args.output_mode();
@@ -893,8 +898,8 @@ impl DeployArgs {
         // Past the dry-run return a signer was always resolved above.
         let signer = signer.ok_or(crate::wallet::WalletError::NoWallet)?;
 
-        let api = ApiArgs::headless(self.api_url.clone());
-        ApplyArgs::ensure_fresh_auth(config, cli_args, &self.api_url).await?;
+        let api = ApiArgs::headless(self.resolved_api_url());
+        ApplyArgs::ensure_fresh_auth(config, cli_args, &self.resolved_api_url()).await?;
 
         // Warn before step 1: creating a project POSTs and rewrites
         // credible.toml, so a warning printed after it would arrive once
@@ -991,7 +996,7 @@ impl DeployArgs {
                     &CreateIntent {
                         project_name: name.clone(),
                         chain_id,
-                        platform_url: self.api_url.as_str().trim_end_matches('/').to_string(),
+                        platform_url: crate::platform::trim_platform_url(&self.resolved_api_url()),
                     },
                 )?;
                 progress(
@@ -1216,7 +1221,7 @@ impl DeployArgs {
                 ReleaseStep::Create => {
                     if human {
                         print!("{}", preview.render_plan());
-                        if !self.yes && !confirm_apply()? {
+                        if !self.yes && !confirm_apply(&self.resolved_api_url())? {
                             return Err(DeployError::Cancelled);
                         }
                     }
@@ -1301,7 +1306,7 @@ impl DeployArgs {
         intent_path: &Path,
         human: bool,
     ) -> Result<(Uuid, Value), DeployError> {
-        let requested = self.api_url.as_str().trim_end_matches('/').to_string();
+        let requested = crate::platform::trim_platform_url(&self.resolved_api_url());
         if intent.platform_url != requested {
             // The unresolved create belongs to another platform; matching
             // this platform's projects against it proves nothing.
@@ -1383,7 +1388,7 @@ impl DeployArgs {
         &self,
         config: &CliConfig,
     ) -> Result<dapp_api_client::generated::client::Client, DeployError> {
-        crate::client::authenticated_client(config, &self.api_url)
+        crate::client::authenticated_client(config, &self.resolved_api_url())
             .map_err(crate::apply::client_error_to_apply)
             .map_err(DeployError::Apply)
     }
@@ -1457,7 +1462,8 @@ impl DeployArgs {
         chain_id: Option<u64>,
         findings: &[V2SpecFinding],
     ) -> Vec<Value> {
-        let Some(message) = assertion_spec::deploy_warning(&self.api_url, chain_id, findings)
+        let Some(message) =
+            assertion_spec::deploy_warning(&self.resolved_api_url(), chain_id, findings)
         else {
             return Vec::new();
         };
@@ -1466,7 +1472,7 @@ impl DeployArgs {
         }
         vec![assertion_spec::warning_json(
             &message,
-            &self.api_url,
+            &self.resolved_api_url(),
             chain_id,
             findings,
         )]

--- a/crates/pcl/core/src/download.rs
+++ b/crates/pcl/core/src/download.rs
@@ -62,10 +62,17 @@ pub struct DownloadArgs {
         long = "api-url",
         env = "PCL_API_URL",
         value_hint = clap::ValueHint::Url,
-        default_value = crate::config::default_platform_url(),
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    pub api_url: url::Url,
+    pub api_url: Option<url::Url>,
+}
+
+impl DownloadArgs {
+    /// Platform URL for this run: the explicit `-u`/`PCL_API_URL` value when
+    /// given, otherwise the platform resolved during startup.
+    fn resolved_api_url(&self) -> url::Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -137,7 +144,7 @@ impl DownloadArgs {
     ) -> Result<(), DownloadError> {
         let output_mode = cli_args.output_mode();
 
-        ensure_fresh_auth(config, &self.api_url, cli_args)
+        ensure_fresh_auth(config, &self.resolved_api_url(), cli_args)
             .await
             .map_err(client_error_to_download)?;
         let client = self.build_client(config)?;
@@ -328,7 +335,7 @@ impl DownloadArgs {
     }
 
     fn build_client(&self, config: &CliConfig) -> Result<GeneratedClient, DownloadError> {
-        authenticated_client(config, &self.api_url).map_err(client_error_to_download)
+        authenticated_client(config, &self.resolved_api_url()).map_err(client_error_to_download)
     }
 
     async fn resolve_project(

--- a/crates/pcl/core/src/error.rs
+++ b/crates/pcl/core/src/error.rs
@@ -68,6 +68,9 @@ pub enum ApplyError {
     #[error("Apply cancelled")]
     ApplyCancelled,
 
+    #[error(transparent)]
+    Platform(#[from] PlatformError),
+
     #[error("JSON mode with pending changes requires `--yes`")]
     JsonConfirmationRequiresYes,
 
@@ -292,6 +295,22 @@ pub enum ConfigError {
     /// Error when a config value supplied on the command line is invalid
     #[error("Invalid config value: {0}")]
     InvalidValue(String),
+}
+
+/// Errors that can occur while resolving which platform to talk to.
+#[derive(Error, Debug)]
+pub enum PlatformError {
+    /// Nothing resolved a platform and there is no terminal to choose one on.
+    /// `pcl` has no compiled-in default, so this is a hard stop rather than a
+    /// silent fallback to a host that may no longer serve the dApp.
+    #[error(
+        "No platform selected. Pass `-u <url>` or set `PCL_API_URL`, or run `pcl auth login` from a terminal to choose one. Production networks: {networks}"
+    )]
+    NoPlatformResolved { networks: String },
+
+    /// The interactive network selector was cancelled or failed.
+    #[error("Network selection failed: {0}")]
+    SelectionFailed(#[source] inquire::InquireError),
 }
 
 /// Errors that can occur during authentication operations

--- a/crates/pcl/core/src/error.rs
+++ b/crates/pcl/core/src/error.rs
@@ -295,6 +295,10 @@ pub enum ConfigError {
     /// Error when a config value supplied on the command line is invalid
     #[error("Invalid config value: {0}")]
     InvalidValue(String),
+
+    /// Error when another local process held the config lock for too long.
+    #[error("Timed out waiting for another PCL process to finish writing the config.")]
+    LockTimeout,
 }
 
 /// Errors that can occur while resolving which platform to talk to.

--- a/crates/pcl/core/src/lib.rs
+++ b/crates/pcl/core/src/lib.rs
@@ -18,11 +18,9 @@ pub mod download;
 pub mod error;
 pub mod onchain;
 pub mod output;
+pub mod platform;
 pub mod request_log;
 pub mod surface;
 #[cfg(feature = "credible")]
 pub mod verify;
 pub mod wallet;
-
-/// Default platform url. URL suffixes added on demand.
-pub const DEFAULT_PLATFORM_URL: &str = "https://app.phylax.systems";

--- a/crates/pcl/core/src/platform.rs
+++ b/crates/pcl/core/src/platform.rs
@@ -1,0 +1,599 @@
+//! Platform (network) resolution for every command that talks to the API.
+//!
+//! `pcl` deliberately has no compiled-in default platform. A hardcoded default
+//! pins one network into the binary, and the moment that network moves, the
+//! released CLI silently points every request at a host that no longer serves
+//! the dApp. Users upgrade via `brew` on their own schedule, so a bad default
+//! outlives the fix that removes it. A stale interactive *list* still works; a
+//! stale *default* does not.
+//!
+//! Resolution order:
+//!
+//! 1. `-u` / `--api-url` / `--auth-url`, or `PCL_API_URL` / `PCL_AUTH_URL`
+//!    (clap populates flag and env into the same `Option<Url>`). Any URL is
+//!    accepted, so shadow and staging targets keep working.
+//! 2. The platform remembered from the last login or selection.
+//! 3. On a terminal, with human output: pick between the production networks.
+//!    The choice is remembered, so the prompt is one-time.
+//! 4. Otherwise: a hard error naming `-u` and `PCL_API_URL`. Never a hanging
+//!    prompt in CI.
+
+use crate::{
+    config::CliConfig,
+    error::PlatformError,
+};
+use inquire::Select;
+use std::{
+    fmt,
+    io::{
+        IsTerminal,
+        stdin,
+        stdout,
+    },
+};
+pub use url::Url;
+
+/// A production network offered by the interactive selector.
+///
+/// The list is deliberately hardcoded and deliberately short: it exists only
+/// so a first-run user can get to a working platform without reading docs.
+/// Fetching it from the selector page would make the CLI depend on the very
+/// host it is trying to discover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Network {
+    EthereumMainnet,
+    LineaMainnet,
+}
+
+/// Every network the selector offers, in display order.
+pub const SELECTABLE_NETWORKS: [Network; 2] = [Network::EthereumMainnet, Network::LineaMainnet];
+
+impl Network {
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::EthereumMainnet => "Ethereum Mainnet",
+            Self::LineaMainnet => "Linea Mainnet",
+        }
+    }
+
+    pub const fn host(self) -> &'static str {
+        match self {
+            Self::EthereumMainnet => "ethereum.phylax.systems",
+            Self::LineaMainnet => "linea.phylax.systems",
+        }
+    }
+
+    /// Platform URL for this network.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the hosts are compile-time constants that form valid
+    /// `https` URLs, and `selector_hosts_are_valid_urls` covers every variant.
+    pub fn url(self) -> Url {
+        let host = self.host();
+        format!("https://{host}")
+            .parse()
+            .expect("network host forms a valid https URL")
+    }
+
+    /// Recognises a resolved URL as one of the known networks, so it can be
+    /// named in output. Unknown hosts (shadow, staging, localhost) return
+    /// `None` and are shown as-is.
+    pub fn from_url(url: &Url) -> Option<Self> {
+        let host = url.host_str()?;
+        SELECTABLE_NETWORKS
+            .into_iter()
+            .find(|network| network.host() == host)
+    }
+}
+
+impl fmt::Display for Network {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{} ({})", self.display_name(), self.host())
+    }
+}
+
+/// Human label for a resolved platform: the network name when the host is a
+/// known network, otherwise the bare URL.
+pub fn describe_platform(url: &Url) -> String {
+    Network::from_url(url).map_or_else(|| trim_platform_url(url), |network| network.to_string())
+}
+
+/// Canonical stored form of a platform URL — trailing slash removed so
+/// comparisons against remembered values and credential platforms are stable.
+pub fn trim_platform_url(url: &Url) -> String {
+    url.as_str().trim_end_matches('/').to_string()
+}
+
+/// Whether the resolver is allowed to prompt when nothing is configured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interaction {
+    /// A terminal is attached and output is human — the selector may prompt.
+    Prompt,
+    /// Machine output or no terminal — resolution must fail rather than hang.
+    Forbidden,
+}
+
+impl Interaction {
+    /// Prompting requires both a terminal to draw on and a human-output run:
+    /// `--json` is machine consumption even from an interactive shell.
+    pub fn detect(json_output: bool) -> Self {
+        if !json_output && stdin().is_terminal() && stdout().is_terminal() {
+            Self::Prompt
+        } else {
+            Self::Forbidden
+        }
+    }
+}
+
+/// Where a resolved platform came from. Determines whether the choice needs
+/// writing back to the config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlatformSource {
+    /// An explicit `-u`/`--api-url`/`--auth-url` flag or `PCL_*` env var.
+    Explicit,
+    /// The platform remembered from a previous login or selection.
+    Remembered,
+    /// Freshly picked from the interactive selector.
+    Selected,
+}
+
+/// A resolved platform and its provenance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolution {
+    pub url: Url,
+    pub source: PlatformSource,
+}
+
+/// Resolves the platform URL for this invocation, delegating the interactive
+/// pick to `select` so the precedence rules can be tested without a terminal.
+pub fn resolve_platform_url_with<S>(
+    explicit: Option<&Url>,
+    remembered: Option<&str>,
+    interaction: Interaction,
+    select: S,
+) -> Result<Resolution, PlatformError>
+where
+    S: FnOnce() -> Result<Network, PlatformError>,
+{
+    if let Some(url) = explicit {
+        return Ok(Resolution {
+            url: url.clone(),
+            source: PlatformSource::Explicit,
+        });
+    }
+
+    if let Some(remembered) = remembered
+        && let Ok(url) = remembered.parse::<Url>()
+    {
+        return Ok(Resolution {
+            url,
+            source: PlatformSource::Remembered,
+        });
+    }
+
+    if interaction == Interaction::Forbidden {
+        return Err(PlatformError::NoPlatformResolved {
+            networks: network_list(),
+        });
+    }
+
+    Ok(Resolution {
+        url: select()?.url(),
+        source: PlatformSource::Selected,
+    })
+}
+
+/// Resolves the platform URL, prompting interactively when allowed.
+pub fn resolve_platform_url(
+    explicit: Option<&Url>,
+    remembered: Option<&str>,
+    interaction: Interaction,
+) -> Result<Resolution, PlatformError> {
+    resolve_platform_url_with(explicit, remembered, interaction, select_network)
+}
+
+/// Resolves the platform for this invocation and records the choice in
+/// `config` when it must be remembered.
+///
+/// A fresh selection is always remembered, so the prompt is one-time. An
+/// explicit `-u` is remembered only when `persist_explicit` is set — that is,
+/// only for `pcl auth login`. On every other command `-u` is a one-shot
+/// override that must not move the user's platform out from under them.
+pub fn resolve_for_invocation(
+    explicit: Option<&Url>,
+    config: &mut CliConfig,
+    persist_explicit: bool,
+    interaction: Interaction,
+) -> Result<Url, PlatformError> {
+    resolve_for_invocation_with(
+        explicit,
+        config,
+        persist_explicit,
+        interaction,
+        select_network,
+    )
+}
+
+/// [`resolve_for_invocation`] with an injectable selector, so the persistence
+/// rules can be tested without a terminal.
+pub fn resolve_for_invocation_with<S>(
+    explicit: Option<&Url>,
+    config: &mut CliConfig,
+    persist_explicit: bool,
+    interaction: Interaction,
+    select: S,
+) -> Result<Url, PlatformError>
+where
+    S: FnOnce() -> Result<Network, PlatformError>,
+{
+    let resolution = resolve_platform_url_with(
+        explicit,
+        config.platform_url.as_deref(),
+        interaction,
+        select,
+    )?;
+    let should_remember = match resolution.source {
+        PlatformSource::Selected => true,
+        PlatformSource::Explicit => persist_explicit,
+        PlatformSource::Remembered => false,
+    };
+    if should_remember {
+        config.platform_url = Some(trim_platform_url(&resolution.url));
+    }
+    Ok(resolution.url)
+}
+
+fn select_network() -> Result<Network, PlatformError> {
+    let options: Vec<String> = SELECTABLE_NETWORKS
+        .into_iter()
+        .map(|network| network.to_string())
+        .collect();
+    let selected = Select::new("Select the network to use:", options)
+        .with_help_message("Remembered for future commands. Skip with -u <url>.")
+        .prompt()
+        .map_err(PlatformError::SelectionFailed)?;
+
+    SELECTABLE_NETWORKS
+        .into_iter()
+        .find(|network| network.to_string() == selected)
+        .ok_or_else(|| {
+            PlatformError::NoPlatformResolved {
+                networks: network_list(),
+            }
+        })
+}
+
+/// The networks named in the non-interactive error, so a CI failure tells the
+/// operator exactly what to pass.
+fn network_list() -> String {
+    SELECTABLE_NETWORKS
+        .into_iter()
+        .map(|network| format!("{} ({})", network.display_name(), network.url()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Storage for the platform resolved at startup.
+///
+/// In a real run this is set once, before dispatch, and never changes. Unit
+/// tests run concurrently in a single process, so test builds keep it
+/// per-thread: each test installs its own platform without racing the others.
+#[cfg(not(test))]
+mod active {
+    use super::Url;
+    use std::sync::OnceLock;
+
+    static ACTIVE_PLATFORM: OnceLock<Url> = OnceLock::new();
+
+    pub(super) fn set(url: Url) {
+        let _ = ACTIVE_PLATFORM.set(url);
+    }
+
+    pub(super) fn get() -> Option<Url> {
+        ACTIVE_PLATFORM.get().cloned()
+    }
+}
+
+#[cfg(test)]
+mod active {
+    use super::Url;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static ACTIVE_PLATFORM: RefCell<Option<Url>> = const { RefCell::new(None) };
+    }
+
+    pub(super) fn set(url: Url) {
+        ACTIVE_PLATFORM.with(|slot| *slot.borrow_mut() = Some(url));
+    }
+
+    pub(super) fn get() -> Option<Url> {
+        ACTIVE_PLATFORM.with(|slot| slot.borrow().clone())
+    }
+}
+
+/// Records the platform resolved during startup so argument accessors can read
+/// it without re-resolving — and without prompting a second time.
+pub fn set_active_platform(url: Url) {
+    active::set(url);
+}
+
+/// The platform resolved during startup.
+///
+/// # Panics
+///
+/// Panics when startup resolved no platform. Every command that reports
+/// `needs_platform_url` gets one before dispatch, so this fires only if an
+/// argument accessor runs for a command that declared it needs no platform.
+pub fn active_platform() -> Url {
+    active::get()
+        .expect("startup resolves the platform URL before dispatching a command that needs one")
+}
+
+/// The platform resolved during startup, if any.
+///
+/// For commands that report on a platform without needing one — `pcl auth
+/// status` answering "am I logged in?" before any platform has been chosen.
+pub fn active_platform_opt() -> Option<Url> {
+    active::get()
+}
+
+/// The platform an argument struct should use: its own explicit flag when
+/// given, otherwise the platform resolved at startup.
+pub fn platform_url_or_active(explicit: Option<&Url>) -> Url {
+    explicit.cloned().unwrap_or_else(active_platform)
+}
+
+/// The platform resolved at startup, as a recoverable error when none exists.
+///
+/// For paths a command reaches only sometimes — `pcl apply --dry-run` needs a
+/// platform only when it has to pick a project, which is not knowable before
+/// `credible.toml` is read.
+pub fn require_active_platform() -> Result<Url, PlatformError> {
+    active_platform_opt().ok_or_else(|| {
+        PlatformError::NoPlatformResolved {
+            networks: network_list(),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(value: &str) -> Url {
+        value.parse().expect("test URL parses")
+    }
+
+    fn unreachable_select() -> Result<Network, PlatformError> {
+        panic!("selector must not run when a platform is already resolvable")
+    }
+
+    #[test]
+    fn networks_render_name_and_host() {
+        assert_eq!(
+            Network::EthereumMainnet.to_string(),
+            "Ethereum Mainnet (ethereum.phylax.systems)"
+        );
+        assert_eq!(
+            Network::LineaMainnet.to_string(),
+            "Linea Mainnet (linea.phylax.systems)"
+        );
+    }
+
+    #[test]
+    fn selector_offers_exactly_the_two_production_networks() {
+        assert_eq!(
+            SELECTABLE_NETWORKS,
+            [Network::EthereumMainnet, Network::LineaMainnet]
+        );
+    }
+
+    #[test]
+    fn network_urls_are_https_hosts() {
+        assert_eq!(
+            Network::EthereumMainnet.url().as_str(),
+            "https://ethereum.phylax.systems/"
+        );
+        assert_eq!(
+            Network::LineaMainnet.url().as_str(),
+            "https://linea.phylax.systems/"
+        );
+    }
+
+    #[test]
+    fn known_hosts_are_named_and_custom_hosts_are_shown_verbatim() {
+        assert_eq!(
+            describe_platform(&url("https://linea.phylax.systems")),
+            "Linea Mainnet (linea.phylax.systems)"
+        );
+        assert_eq!(
+            describe_platform(&url("https://shadow.phylax.example/")),
+            "https://shadow.phylax.example"
+        );
+    }
+
+    #[test]
+    fn explicit_url_wins_over_remembered() {
+        let explicit = url("https://shadow.phylax.example");
+        let resolution = resolve_platform_url_with(
+            Some(&explicit),
+            Some("https://linea.phylax.systems"),
+            Interaction::Prompt,
+            unreachable_select,
+        )
+        .expect("explicit URL resolves");
+
+        assert_eq!(resolution.url, explicit);
+        assert_eq!(resolution.source, PlatformSource::Explicit);
+    }
+
+    #[test]
+    fn explicit_url_is_accepted_without_being_a_known_network() {
+        // The internal team targets shadow and staging via -u; the selector
+        // must never restrict what an explicit flag accepts.
+        let explicit = url("http://localhost:3000");
+        let resolution = resolve_platform_url_with(
+            Some(&explicit),
+            None,
+            Interaction::Forbidden,
+            unreachable_select,
+        )
+        .expect("arbitrary explicit URL resolves even without a terminal");
+
+        assert_eq!(resolution.url, explicit);
+    }
+
+    #[test]
+    fn remembered_url_is_used_when_no_flag_is_given() {
+        let resolution = resolve_platform_url_with(
+            None,
+            Some("https://ethereum.phylax.systems"),
+            Interaction::Forbidden,
+            unreachable_select,
+        )
+        .expect("remembered URL resolves without prompting");
+
+        assert_eq!(resolution.url, url("https://ethereum.phylax.systems"));
+        assert_eq!(resolution.source, PlatformSource::Remembered);
+    }
+
+    #[test]
+    fn unparseable_remembered_url_falls_through_to_selection() {
+        let resolution =
+            resolve_platform_url_with(None, Some("not-a-url"), Interaction::Prompt, || {
+                Ok(Network::LineaMainnet)
+            })
+            .expect("corrupt remembered value falls through to the selector");
+
+        assert_eq!(resolution.source, PlatformSource::Selected);
+        assert_eq!(resolution.url, Network::LineaMainnet.url());
+    }
+
+    #[test]
+    fn nothing_resolved_without_a_terminal_is_an_error_naming_the_overrides() {
+        let error =
+            resolve_platform_url_with(None, None, Interaction::Forbidden, unreachable_select)
+                .expect_err("non-interactive runs must fail rather than prompt");
+
+        let message = error.to_string();
+        assert!(message.contains("-u"), "should name -u: {message}");
+        assert!(
+            message.contains("PCL_API_URL"),
+            "should name PCL_API_URL: {message}"
+        );
+        assert!(
+            message.contains("ethereum.phylax.systems") && message.contains("linea.phylax.systems"),
+            "should list both networks: {message}"
+        );
+    }
+
+    #[test]
+    fn nothing_resolved_on_a_terminal_prompts() {
+        let resolution = resolve_platform_url_with(None, None, Interaction::Prompt, || {
+            Ok(Network::EthereumMainnet)
+        })
+        .expect("selection resolves");
+
+        assert_eq!(resolution.source, PlatformSource::Selected);
+        assert_eq!(resolution.url, Network::EthereumMainnet.url());
+    }
+
+    #[test]
+    fn json_output_never_prompts_even_on_a_terminal() {
+        // A --json run is machine consumption; a prompt would corrupt it.
+        assert_eq!(Interaction::detect(true), Interaction::Forbidden);
+    }
+
+    #[test]
+    fn a_fresh_selection_is_always_remembered() {
+        // The prompt has to be one-time, so the pick is recorded even on a
+        // command that never persists an explicit `-u`.
+        let mut config = CliConfig::default();
+        let resolved =
+            resolve_for_invocation_with(None, &mut config, false, Interaction::Prompt, || {
+                Ok(Network::EthereumMainnet)
+            })
+            .expect("selection resolves");
+
+        assert_eq!(resolved, Network::EthereumMainnet.url());
+        assert_eq!(
+            config.platform_url.as_deref(),
+            Some("https://ethereum.phylax.systems")
+        );
+    }
+
+    #[test]
+    fn explicit_url_is_one_shot_off_the_login_path() {
+        let mut config = CliConfig {
+            platform_url: Some("https://linea.phylax.systems".to_string()),
+            ..CliConfig::default()
+        };
+        let explicit = url("https://shadow.phylax.example");
+
+        let resolved =
+            resolve_for_invocation(Some(&explicit), &mut config, false, Interaction::Forbidden)
+                .expect("explicit URL resolves");
+
+        assert_eq!(resolved, explicit);
+        assert_eq!(
+            config.platform_url.as_deref(),
+            Some("https://linea.phylax.systems"),
+            "a one-shot -u must not move the remembered platform"
+        );
+    }
+
+    #[test]
+    fn explicit_url_persists_on_the_login_path() {
+        let mut config = CliConfig {
+            platform_url: Some("https://linea.phylax.systems".to_string()),
+            ..CliConfig::default()
+        };
+        let explicit = url("https://shadow.phylax.example/");
+
+        let resolved =
+            resolve_for_invocation(Some(&explicit), &mut config, true, Interaction::Forbidden)
+                .expect("explicit URL resolves");
+
+        assert_eq!(resolved, explicit);
+        assert_eq!(
+            config.platform_url.as_deref(),
+            Some("https://shadow.phylax.example"),
+            "pcl auth login records the platform it logged into"
+        );
+    }
+
+    #[test]
+    fn resolving_from_the_remembered_platform_leaves_the_config_untouched() {
+        let mut config = CliConfig {
+            platform_url: Some("https://linea.phylax.systems".to_string()),
+            ..CliConfig::default()
+        };
+        let before = config.clone();
+
+        let resolved = resolve_for_invocation(None, &mut config, true, Interaction::Forbidden)
+            .expect("remembered URL resolves");
+
+        assert_eq!(resolved, url("https://linea.phylax.systems"));
+        assert_eq!(config, before, "a no-op resolve must not dirty the config");
+    }
+
+    #[test]
+    fn active_platform_is_absent_until_startup_resolves_one() {
+        assert!(active_platform_opt().is_none());
+        assert!(require_active_platform().is_err());
+
+        set_active_platform(Network::LineaMainnet.url());
+
+        assert_eq!(active_platform_opt(), Some(Network::LineaMainnet.url()));
+        assert_eq!(
+            require_active_platform().expect("resolved"),
+            Network::LineaMainnet.url()
+        );
+        // An explicit flag wins over the startup platform.
+        let explicit = url("https://shadow.phylax.example");
+        assert_eq!(platform_url_or_active(Some(&explicit)), explicit);
+        assert_eq!(platform_url_or_active(None), Network::LineaMainnet.url());
+    }
+}

--- a/crates/pcl/core/src/platform.rs
+++ b/crates/pcl/core/src/platform.rs
@@ -79,7 +79,25 @@ impl Network {
     /// Recognises a resolved URL as one of the known networks, so it can be
     /// named in output. Unknown hosts (shadow, staging, localhost) return
     /// `None` and are shown as-is.
+    ///
+    /// Matching is on the whole canonical origin, not just the host. Requests
+    /// preserve the scheme, port, userinfo, and query, so a URL that differs in
+    /// any of them is a *different target* — and naming it "Linea Mainnet" would
+    /// hide exactly what the announcement exists to expose:
+    /// `http://linea.phylax.systems:8080` is plaintext to another service, and
+    /// `https://user:secret@linea.phylax.systems` delivers credentials on every
+    /// request. Those render as their (redacted) URL instead.
     pub fn from_url(url: &Url) -> Option<Self> {
+        if url.scheme() != "https"
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.port().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+            || !matches!(url.path(), "" | "/")
+        {
+            return None;
+        }
         let host = url.host_str()?;
         SELECTABLE_NETWORKS
             .into_iter()
@@ -93,16 +111,70 @@ impl fmt::Display for Network {
     }
 }
 
-/// Human label for a resolved platform: the network name when the host is a
-/// known network, otherwise the bare URL.
+/// Human label for a resolved platform: the network name when the URL is a known
+/// network's canonical origin, otherwise the redacted URL.
 pub fn describe_platform(url: &Url) -> String {
-    Network::from_url(url).map_or_else(|| trim_platform_url(url), |network| network.to_string())
+    Network::from_url(url).map_or_else(|| redact_platform_url(url), |network| network.to_string())
 }
 
 /// Canonical stored form of a platform URL — trailing slash removed so
 /// comparisons against remembered values and credential platforms are stable.
+///
+/// Lossless on purpose: this is an identity, used for storage and for the
+/// platform-boundary comparison. Never print it. Use [`redact_platform_url`] or
+/// [`describe_platform`] for anything a human or a log will see.
 pub fn trim_platform_url(url: &Url) -> String {
     url.as_str().trim_end_matches('/').to_string()
+}
+
+/// Display form of a platform URL with any embedded credentials masked.
+///
+/// `PCL_API_URL=https://user:secret@shadow.example` is a supported way to reach
+/// an internal target, and the per-command announcement plus the apply
+/// confirmation would otherwise copy that password into terminal scrollback and
+/// CI logs. Scheme, host, port, and path stay — they are what the reader needs to
+/// confirm the target — and userinfo and query are *masked rather than dropped*:
+/// both ride along on every request, so a display that silently omitted them
+/// would render two different targets identically, which is the same hiding this
+/// function exists to prevent.
+pub fn redact_platform_url(url: &Url) -> String {
+    let has_userinfo = !url.username().is_empty() || url.password().is_some();
+    if !has_userinfo && url.query().is_none() && url.fragment().is_none() {
+        return trim_platform_url(url);
+    }
+    let mut redacted = url.clone();
+    // Both setters fail only on a cannot-be-a-base URL (`mailto:`), which never
+    // reaches here: platform URLs are http(s). On failure the value is left
+    // untouched, so fall back to showing scheme and host only.
+    if has_userinfo
+        && (redacted.set_username("redacted").is_err() || redacted.set_password(None).is_err())
+    {
+        return format!(
+            "{}://{}",
+            url.scheme(),
+            url.host_str().unwrap_or("<unknown host>")
+        );
+    }
+    if url.query().is_some() {
+        redacted.set_query(Some("redacted"));
+    }
+    // Fragments are never sent to a server, so there is nothing to disclose or
+    // to warn about.
+    redacted.set_fragment(None);
+    trim_platform_url(&redacted)
+}
+
+/// [`redact_platform_url`] for a platform URL that is already stored as a
+/// string — a recorded credential issuer, or the platform on a pending deploy
+/// intent.
+///
+/// A value that no longer parses is shown verbatim: it came from this CLI's own
+/// config or intent file, so a parse failure means the file was hand-edited, and
+/// the raw text is the most useful thing to put in front of the operator.
+pub fn redact_stored_platform_url(stored: &str) -> String {
+    stored
+        .parse::<Url>()
+        .map_or_else(|_| stored.to_string(), |url| redact_platform_url(&url))
 }
 
 /// Whether the resolver is allowed to prompt when nothing is configured.
@@ -412,6 +484,105 @@ mod tests {
             describe_platform(&url("https://shadow.phylax.example/")),
             "https://shadow.phylax.example"
         );
+    }
+
+    #[test]
+    fn only_a_canonical_origin_earns_a_network_name() {
+        // Everything here reaches a different target than the network it looks
+        // like — a different scheme, port, path, or an extra credential or query
+        // that rides along on every request. Labelling any of them "Linea
+        // Mainnet" would hide the very difference the announcement exists to
+        // surface.
+        for imposter in [
+            "http://linea.phylax.systems",
+            "http://linea.phylax.systems:8080",
+            "https://linea.phylax.systems:8443",
+            "https://user:secret@linea.phylax.systems",
+            "https://user@linea.phylax.systems",
+            "https://linea.phylax.systems?token=abc",
+            "https://linea.phylax.systems#frag",
+            "https://linea.phylax.systems/staging",
+            "https://linea.phylax.systems.evil.example",
+        ] {
+            let parsed = url(imposter);
+            assert_eq!(
+                Network::from_url(&parsed),
+                None,
+                "{imposter} must not be recognised as a known network"
+            );
+            assert_ne!(
+                describe_platform(&parsed),
+                Network::LineaMainnet.to_string(),
+                "{imposter} must not be labelled as Linea Mainnet"
+            );
+        }
+
+        // The canonical origin still is, with or without the trailing slash.
+        assert_eq!(
+            Network::from_url(&url("https://linea.phylax.systems")),
+            Some(Network::LineaMainnet)
+        );
+        assert_eq!(
+            Network::from_url(&url("https://linea.phylax.systems/")),
+            Some(Network::LineaMainnet)
+        );
+    }
+
+    #[test]
+    fn display_strips_credentials_but_keeps_the_target_identifiable() {
+        // The announcement and the apply confirmation go to stderr, which lands
+        // in terminal scrollback and CI logs.
+        assert_eq!(
+            redact_platform_url(&url("https://alice:sup3rs3cret@shadow.example")),
+            "https://redacted@shadow.example"
+        );
+        assert_eq!(
+            describe_platform(&url("https://alice:sup3rs3cret@shadow.example/")),
+            "https://redacted@shadow.example"
+        );
+        // A query string can carry a token just as easily, and is masked rather
+        // than dropped: it is still sent, so hiding it would make this render
+        // identically to the same host without it.
+        assert_eq!(
+            redact_platform_url(&url("https://shadow.example/api?token=abc#frag")),
+            "https://shadow.example/api?redacted"
+        );
+        assert_ne!(
+            redact_platform_url(&url("https://shadow.example?token=abc")),
+            redact_platform_url(&url("https://shadow.example")),
+            "a query-bearing target must not render as the bare host"
+        );
+        // Host, port, and path survive: they are what identifies the target.
+        assert_eq!(
+            redact_platform_url(&url("http://127.0.0.1:3000/base")),
+            "http://127.0.0.1:3000/base"
+        );
+        // A credential-bearing URL that looks like a known network is never
+        // laundered into that network's name.
+        assert_eq!(
+            describe_platform(&url("https://alice:secret@linea.phylax.systems")),
+            "https://redacted@linea.phylax.systems"
+        );
+
+        for rendered in [
+            redact_platform_url(&url("https://alice:sup3rs3cret@shadow.example")),
+            describe_platform(&url("https://alice:sup3rs3cret@shadow.example")),
+            redact_stored_platform_url("https://alice:sup3rs3cret@shadow.example"),
+        ] {
+            assert!(
+                !rendered.contains("sup3rs3cret"),
+                "password leaked into output: {rendered}"
+            );
+        }
+
+        // Storage and comparison stay lossless — the boundary check depends on
+        // the exact value.
+        assert_eq!(
+            trim_platform_url(&url("https://alice:sup3rs3cret@shadow.example/")),
+            "https://alice:sup3rs3cret@shadow.example"
+        );
+        // A hand-edited config value that no longer parses is shown as-is.
+        assert_eq!(redact_stored_platform_url("not-a-url"), "not-a-url");
     }
 
     #[test]

--- a/crates/pcl/core/src/surface.rs
+++ b/crates/pcl/core/src/surface.rs
@@ -303,12 +303,39 @@ pub struct DoctorArgs {
     #[arg(
         long = "api-url",
         env = "PCL_API_URL",
-        default_value = crate::config::default_platform_url(),
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    api_url: url::Url,
+    api_url: Option<url::Url>,
     #[arg(long, help = "Skip network health checks")]
     offline: bool,
+}
+
+impl DoctorArgs {
+    /// The explicit `--api-url`/`PCL_API_URL` value, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.api_url.as_ref()
+    }
+
+    /// Whether the run skips network checks, and therefore needs no platform.
+    /// Diagnostics must stay runnable before a platform has been chosen.
+    pub fn is_offline(&self) -> bool {
+        self.offline
+    }
+
+    /// Platform for the diagnostic report, which is `null` on an offline run
+    /// before any platform has been chosen.
+    fn reported_api_url(&self) -> Value {
+        self.api_url
+            .clone()
+            .or_else(crate::platform::active_platform_opt)
+            .map_or(Value::Null, |url| json!(url.as_str()))
+    }
+
+    /// Platform URL for this run: the explicit `--api-url`/`PCL_API_URL` value
+    /// when given, otherwise the platform resolved during startup.
+    fn resolved_api_url(&self) -> url::Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
 }
 
 #[derive(clap::Args, Debug)]
@@ -471,12 +498,33 @@ struct ExportIncidentsArgs {
     #[arg(
         long = "api-url",
         env = "PCL_API_URL",
-        default_value = crate::config::default_platform_url(),
-        help = "Base URL for the platform API. Defaults to the URL remembered from the last login"
+        help = "Base URL for the platform API. Defaults to the platform remembered from the last login or network selection"
     )]
-    api_url: url::Url,
+    api_url: Option<url::Url>,
     #[arg(long, help = "Do not attach a stored bearer token")]
     allow_unauthenticated: bool,
+}
+
+impl ExportArgs {
+    /// The explicit `--api-url`/`PCL_API_URL` value from the selected
+    /// subcommand, when one was given.
+    pub fn platform_url_flag(&self) -> Option<&url::Url> {
+        match &self.command {
+            ExportCommand::Incidents(args) => args.platform_url_flag(),
+        }
+    }
+}
+
+impl ExportIncidentsArgs {
+    fn platform_url_flag(&self) -> Option<&url::Url> {
+        self.api_url.as_ref()
+    }
+
+    /// Platform URL for this run: the explicit `--api-url`/`PCL_API_URL` value
+    /// when given, otherwise the platform resolved during startup.
+    fn resolved_api_url(&self) -> url::Url {
+        crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
 }
 
 impl DoctorArgs {
@@ -511,8 +559,8 @@ impl DoctorArgs {
         ];
 
         if !self.offline {
-            checks.push(health_check(&self.api_url).await);
-            checks.push(auth_capability_check(&self.api_url).await);
+            checks.push(health_check(&self.resolved_api_url()).await);
+            checks.push(auth_capability_check(&self.resolved_api_url()).await);
         }
 
         let status = if checks
@@ -538,7 +586,7 @@ impl DoctorArgs {
                     "checks": checks,
                     "default_output": "human",
                     "json_output_flag": "--json",
-                    "api_url": self.api_url.as_str(),
+                    "api_url": self.reported_api_url(),
                 },
                 "next_actions": next_actions,
             }),
@@ -906,7 +954,7 @@ async fn export_incidents(
     ensure_export_auth(
         config,
         cli_args,
-        &args.api_url,
+        &args.resolved_api_url(),
         args.project_id.is_some(),
         args.allow_unauthenticated,
     )
@@ -962,7 +1010,7 @@ async fn export_incidents(
             args.allow_unauthenticated,
         )?)
         .build()?;
-    let client = generated_client_with_http_client(&args.api_url, http_client);
+    let client = generated_client_with_http_client(&args.resolved_api_url(), http_client);
     let project_id = match args.project_id.as_deref() {
         Some(project_ref) => Some(resolve_export_project_id(&client, project_ref).await?),
         None => None,
@@ -1452,7 +1500,7 @@ fn incident_export_resume_command(
         "--max-retries".to_string(),
         args.max_retries.to_string(),
         "--api-url".to_string(),
-        shell_word(args.api_url.as_str()),
+        shell_word(args.resolved_api_url().as_str()),
     ];
 
     if let Some(project_id) = &args.project_id {
@@ -2353,7 +2401,6 @@ fn log_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DEFAULT_PLATFORM_URL;
     use mockito::Matcher;
     use pcl_common::args::CliArgs;
     use std::{
@@ -2648,7 +2695,7 @@ mod tests {
             continue_on_error: true,
             max_retries: 3,
             dry_run: false,
-            api_url: DEFAULT_PLATFORM_URL.parse().unwrap(),
+            api_url: Some("https://linea.phylax.systems".parse().unwrap()),
             allow_unauthenticated: false,
         };
 
@@ -2723,7 +2770,7 @@ mod tests {
             continue_on_error: false,
             max_retries: 1,
             dry_run: false,
-            api_url: server.url().parse().unwrap(),
+            api_url: Some(server.url().parse().unwrap()),
             allow_unauthenticated: true,
         };
 
@@ -2808,7 +2855,7 @@ mod tests {
             continue_on_error: false,
             max_retries: 0,
             dry_run: false,
-            api_url: server.url().parse().unwrap(),
+            api_url: Some(server.url().parse().unwrap()),
             allow_unauthenticated: false,
         };
 
@@ -2866,7 +2913,7 @@ mod tests {
             continue_on_error: false,
             max_retries: 0,
             dry_run: false,
-            api_url: server.url().parse().unwrap(),
+            api_url: Some(server.url().parse().unwrap()),
             allow_unauthenticated: false,
         };
 
@@ -2921,7 +2968,7 @@ mod tests {
             continue_on_error: false,
             max_retries: 0,
             dry_run: false,
-            api_url: server.url().parse().unwrap(),
+            api_url: Some(server.url().parse().unwrap()),
             allow_unauthenticated: false,
         };
 
@@ -2936,9 +2983,11 @@ mod tests {
     #[tokio::test]
     async fn incident_export_records_failed_job_after_network_failure() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap())
-            .parse()
-            .unwrap();
+        let api_url = Some(
+            format!("http://{}", listener.local_addr().unwrap())
+                .parse()
+                .unwrap(),
+        );
         drop(listener);
 
         let temp = tempdir().unwrap();
@@ -3031,7 +3080,7 @@ mod tests {
             continue_on_error: true,
             max_retries: 0,
             dry_run: false,
-            api_url: server.url().parse().unwrap(),
+            api_url: Some(server.url().parse().unwrap()),
             allow_unauthenticated: true,
         };
 

--- a/crates/pcl/core/src/surface.rs
+++ b/crates/pcl/core/src/surface.rs
@@ -513,6 +513,13 @@ impl ExportArgs {
             ExportCommand::Incidents(args) => args.platform_url_flag(),
         }
     }
+
+    /// Whether the selected subcommand reaches the platform.
+    pub fn needs_platform_url(&self) -> bool {
+        match &self.command {
+            ExportCommand::Incidents(args) => args.needs_platform_url(),
+        }
+    }
 }
 
 impl ExportIncidentsArgs {
@@ -520,10 +527,27 @@ impl ExportIncidentsArgs {
         self.api_url.as_ref()
     }
 
+    /// Whether this run reaches the platform. A `--dry-run` prints its plan and
+    /// fetches nothing, so it must work on a clean install without a platform.
+    fn needs_platform_url(&self) -> bool {
+        !self.dry_run
+    }
+
     /// Platform URL for this run: the explicit `--api-url`/`PCL_API_URL` value
     /// when given, otherwise the platform resolved during startup.
     fn resolved_api_url(&self) -> url::Url {
         crate::platform::platform_url_or_active(self.api_url.as_ref())
+    }
+
+    /// Platform URL to pin in the resume command, when one is known.
+    ///
+    /// A dry run may have resolved no platform. Rather than inventing one, the
+    /// resume command omits `--api-url` and lets the real execution resolve it
+    /// the same way any other command would.
+    fn resume_api_url(&self) -> Option<url::Url> {
+        self.api_url
+            .clone()
+            .or_else(crate::platform::active_platform_opt)
     }
 }
 
@@ -1499,9 +1523,15 @@ fn incident_export_resume_command(
         args.max_pages.to_string(),
         "--max-retries".to_string(),
         args.max_retries.to_string(),
-        "--api-url".to_string(),
-        shell_word(args.resolved_api_url().as_str()),
     ];
+
+    // Pinned so a resume targets the same platform this plan described — but
+    // only when there is one to pin. The value is deliberately not redacted:
+    // this line is meant to be copied and run.
+    if let Some(api_url) = args.resume_api_url() {
+        parts.push("--api-url".to_string());
+        parts.push(shell_word(api_url.as_str()));
+    }
 
     if let Some(project_id) = &args.project_id {
         parts.push("--project-id".to_string());
@@ -2488,6 +2518,7 @@ mod tests {
         let config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "expired-token".to_string(),
                 refresh_token: "refresh-token".to_string(),
                 expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),
@@ -2540,6 +2571,7 @@ mod tests {
         );
 
         let auth = UserAuth {
+            issuer_platform_url: None,
             access_token: "expired-token".to_string(),
             refresh_token: "refresh-token".to_string(),
             expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),
@@ -2828,6 +2860,7 @@ mod tests {
         let mut config = CliConfig {
             rpc: BTreeMap::default(),
             auth: Some(UserAuth {
+                issuer_platform_url: Some(server.url()),
                 access_token: "old_access".to_string(),
                 refresh_token: "old_refresh".to_string(),
                 expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),
@@ -2889,6 +2922,7 @@ mod tests {
         };
         let mut config = CliConfig {
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "valid_access".to_string(),
                 refresh_token: "valid_refresh".to_string(),
                 expires_at: chrono::Utc::now() + chrono::Duration::hours(2),
@@ -2944,6 +2978,7 @@ mod tests {
         };
         let mut config = CliConfig {
             auth: Some(UserAuth {
+                issuer_platform_url: None,
                 access_token: "old_access".to_string(),
                 refresh_token: "old_refresh".to_string(),
                 expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),

--- a/scripts/agent-smoke.sh
+++ b/scripts/agent-smoke.sh
@@ -12,7 +12,12 @@ expired_auth_config_dir="$(mktemp -d)"
 verify_project_dir="$(mktemp -d)"
 trap 'rm -rf "$config_dir" "$missing_auth_config_dir" "$expired_auth_config_dir" "$verify_project_dir"' EXIT
 
+# `platform_url` is recorded because there is no default platform: every
+# command that talks to the API resolves one from the flag, the environment, or
+# this remembered value, and errors rather than prompting when run non-TTY.
 cat > "$config_dir/config.toml" <<'CONFIG'
+platform_url = "https://linea.phylax.systems"
+
 [auth]
 access_token = "agent-smoke-token"
 refresh_token = "agent-smoke-refresh-token"


### PR DESCRIPTION
Closes ENG-4201.

`pcl` defaulted to `app.phylax.systems` whenever no `-u` was passed and no platform was remembered. Once `app.` becomes the network selector, that default points at a host which no longer serves the dApp — and because users upgrade via `brew` on their own schedule, a bad default outlives the release that removes it.

Rather than repoint the default, this removes it. Any hardcoded default bakes one network into the binary and recreates this bug when the next network ships. A stale interactive *list* still works; a stale *default* does not.

<img width="448" height="104" alt="image" src="https://github.com/user-attachments/assets/28c65c8f-5535-4e80-89b9-b62d84f85d2d" />

## Resolution order

1. `-u` / `--api-url` / `--auth-url`, or `PCL_API_URL` / `PCL_AUTH_URL` — accepts **any** URL, so shadow and staging workflows are unaffected.
2. The remembered platform.
3. On a terminal: a one-time pick between `Ethereum Mainnet (ethereum.phylax.systems)` and `Linea Mainnet (linea.phylax.systems)`, which is remembered.
4. Nothing resolved, no terminal: a hard error naming `-u` and `PCL_API_URL` — never a hanging prompt.

`--json` counts as non-interactive even from a terminal, so machine output is never corrupted by a prompt.

## Why the arg types changed

`api_url` was a non-`Option` `Url` that clap always populated via `default_value`. That expression is evaluated at **command-build time**, for every invocation including `pcl --help` and shell completions — so the picker could not live there without prompting on `--help`. Removing the default forces `Option<Url>` across the 7 arg structs, with resolution moved to a single pre-dispatch step in `main.rs`. The ~31 read sites go through a `resolved_api_url()` accessor per struct.

Resolving once keeps the prompt one-time, persists a fresh pick through the existing remembered-platform mechanism, and gives every platform-facing command one place to announce its target (`Using Linea Mainnet (linea.phylax.systems)`, stderr, human output only). `pcl apply`'s confirmation names the network too.

Commands that only read local state — `auth status`, `doctor --offline`, `api manifest`, `apply --dry-run` — resolve a platform when one is already known, but never prompt or fail for one.

## Two upgrade consequences for release notes

- **Every existing production user hits the one-time prompt** (or the CI error) on their first post-upgrade run, because production logins were deliberately never recorded.
- **Credentials with no recorded platform force one re-login.** They can no longer be assumed to be production, so the platform-boundary check treats them as a switch. The alternative is sending a token to a platform that did not issue it.

The "production = not remembered" sentinel disappears with the default: `remember_platform_url` now always records the platform it logged into, and `apply`'s command-line reconstruction pins `--api-url` only when the user actually passed one.

## Worth a close look

- **`auth.rs` platform-boundary change** — `credential_platform` returns `Option`, and an unrecorded platform now counts as switching. This is the security-relevant hunk.
- **Config persistence in `main.rs`** — a newly chosen platform is written *before* the command runs. Deferring it to the post-command write loses the choice on any failure and re-prompts on the next run (caught in manual testing; regression test added). The immediate write also refreshes the process-start snapshot, or `write_to_file_if_unchanged` would silently stop persisting later changes like refreshed auth tokens.
- **`client.rs`** — the API base URL was already derived from the resolved platform, but nothing locked it in. Extracted to `api_base_url` with tests asserting `dapp.`/`app.` never appear: `dapp.phylax.systems` answers with a 301, and reqwest downgrades a redirected POST to GET, which would silently drop request bodies.
- **`api manifest` and `--body-template`** — `manifest` is exempt from needing a platform (it is static). `--body-template` runs are **not** exempt, because the flag lives on ~12 separate workflow arg structs with no shared predicate. Happy to add the accessors if you would rather those worked with no config.

## Verification

`make ci` equivalent all green: fmt, clippy (`-D warnings -D clippy::pedantic`), full-check, release-check, doc, diff-check, agent-smoke, and 17/17 test suites.

Behaviour also exercised against the built binary, not just tests — first-run picker, sticky second run, non-TTY error, arbitrary `-u` URLs (shadow + localhost), `-u` staying one-shot off the login path, and stdout/stderr separation in `--json`.

Two ACs are out of scope here: end-to-end exercise against the post-cutover hosts, and the release plus minimum-version note on ENG-4178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
