### PR TITLE
chore(release): bump to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "dapp-api-client"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -9256,7 +9256,7 @@ dependencies = [
 
 [[package]]
 name = "pcl"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "chrono",
  "clap",
@@ -9273,7 +9273,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-common"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -9281,7 +9281,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-core"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -9322,7 +9322,7 @@ dependencies = [
 
 [[package]]
 name = "pcl-phoundry"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "alloy-json-abi",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 authors = ["Phylax Systems"]
 license = "BSL 1.1"


### PR DESCRIPTION
Bumps PCL from 1.7.0 to 1.8.0.

This release includes #121, which removes the stale default platform URL and adds explicit platform resolution for Ethereum Mainnet, Linea Mainnet, and custom URLs. Jacob verified the merged client against the currently deployed platform versions.

Upgrade notes:
- Existing production users will see a one-time platform-selection prompt.
- Non-interactive and CI runs without remembered configuration must set `PCL_API_URL` or pass `--api-url`.
- Credentials without recorded issuer provenance require a one-time re-login.

The workspace version also versions the committed generated `dapp-api-client` crate as 1.8.0. A separate follow-up should make its generation provenance explicitly traceable to a released dApp version.

Merging to `main` triggers the `1.8.0` tag, binary build, GitHub release, and Homebrew publication workflow.

Validation:
- `cargo +nightly-2026-07-28 fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check --locked --workspace --all-targets --features full`

Prompted by: Odysseus
